### PR TITLE
Match seven more Tier 2 near-miss functions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1924,6 +1924,16 @@ config.custom_build_rules = [
         "description": "EXTERNALIZE $in",
     },
     {
+        "name": "externalize_game_800C65FC_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @30 && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@30=lbl_8064F158 --remove-section=.sdata2 $in "
+            "&& touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
         "name": "externalize_game_800C644C_bias",
         "command": (
             "python3 tools/externalize_elf_symbol.py $in @15 && "
@@ -3005,6 +3015,11 @@ config.custom_build_steps = {
             "outputs": [f"build/{VERSION}/src/game/game_fn_800C644C.externalized"],
             "rule": "externalize_game_800C644C_bias",
             "inputs": [f"build/{VERSION}/src/game/game_fn_800C644C.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_800C65FC.externalized"],
+            "rule": "externalize_game_800C65FC_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_800C65FC.o"],
         },
         {
             "outputs": [f"build/{VERSION}/src/game/game_fn_800CB760.externalized"],
@@ -5797,7 +5812,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800AFCD0.c"),
             Object(Matching, "game/game_fn_800AFDA4.c"),
             Object(Matching, "game/game_fn_800AFE30.c"),
-            Object(NonMatching, "game/game_fn_800AFEC0.c"),
+            Object(Matching, "game/game_fn_800AFEC0.c"),
             Object(NonMatching, "game/game_fn_800B002C.c"),
             Object(Matching, "game/game_fn_800B01D8.c"),
             Object(Matching, "game/game_fn_800B035C.c"),
@@ -6010,7 +6025,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800C61F8.c"),
             Object(Matching, "game/game_fn_800C63D8.c"),
             Object(Matching, "game/game_fn_800C644C.c"),
-            Object(NonMatching, "game/game_fn_800C65FC.c"),
+            Object(Matching, "game/game_fn_800C65FC.c"),
             Object(Matching, "game/game_fn_800C677C.c"),
             Object(Matching, "game/game_fn_800C6F50.c"),
             Object(Matching, "game/game_fn_800C7028.c"),
@@ -7071,8 +7086,8 @@ config.libs = [
             Object(Matching, "game/game_fn_8012CAC4.c"),
             Object(Matching, "game/game_fn_8012CB60.c"),
             Object(Matching, "game/game_fn_8012CBE8.c"),
-            Object(NonMatching, "game/game_fn_8012CCF0.c"),
-            Object(NonMatching, "game/game_fn_8012CDF0.c"),
+            Object(Matching, "game/game_fn_8012CCF0.c"),
+            Object(Matching, "game/game_fn_8012CDF0.c"),
             Object(Matching, "game/game_fn_8012CEA4.c"),
             Object(NonMatching, "game/game_fn_8012CF08.c"),
             Object(Matching, "game/game_fn_8012D01C.c"),
@@ -7156,7 +7171,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_80132B24.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_80132C24.c"),
             Object(Matching, "game/game_fn_80132C94.c"),
-            Object(NonMatching, "game/game_fn_80132D50.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80132D50.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801332E0.c"),
             Object(Matching, "game/game_fn_801332E8.c"),
             Object(Matching, "game/game_fn_801332F0.c"),
@@ -7280,7 +7295,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8013D998.c"),
             Object(Matching, "game/game_fn_8013DAA8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8013DB8C.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8013DE44.c"),
+            Object(Matching, "game/game_fn_8013DE44.c"),
             Object(Matching, "game/game_fn_8013DF4C.c"),
             Object(Matching, "game/game_fn_8013E028.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8013E188.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -7923,7 +7938,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_8015F9D4.c"),
             Object(Matching, "game/game_fn_8015FE80.c"),
             Object(Matching, "game/game_fn_8015FEB8.c"),
-            Object(NonMatching, "game/game_fn_8015FF18.c"),
+            Object(Matching, "game/game_fn_8015FF18.c"),
             Object(Matching, "game/game_fn_8015FFE8.c"),
             Object(Matching, "game/game_fn_80160024.c"),
             Object(Matching, "game/game_fn_801600AC.c"),

--- a/docs/matching.md
+++ b/docs/matching.md
@@ -338,3 +338,72 @@ declare it.
 Objdiff reports 64/64 bytes and 3 relocations for `fn_8015AD00`, 108/108 and 4
 for `fn_8015AC94`, and 180/180 and 13 for `fn_8016B400`, all at 100%, and the
 whole-DOL SHA-1 gate remains `ea24b6af954876ce072562ff39cdb4c81d32be1f`.
+
+## Loop form decides constant materialization order
+
+`fn_80132D50` was two instructions from retail: the loop-invariant constants 1
+and 0 were hoisted in the wrong order (`li r31,0` before `li r30,1`; retail
+emits the 1 first). No statement reordering, store spelling, or pointer-typed
+zero moved them. Rewriting the `do { ... i++; } while (i < 5);` loop as
+`for (i = 0; i < 5; i++)` with the cursor advance kept in the body flips the
+materialization order and nothing else: 128/128 bytes, 100%. Rejected as
+byte-neutral: `(void*)0` in the store, swapping the init statements, and
+routing the zero through the object local.
+
+## A slot-pointer sum lands in the product's register when a dead local absorbs it
+
+`fn_8012CDF0` and `fn_8012CCF0` share one epilogue: fetch a runtime array,
+scale an index from the definition, store the entry into the slot. Written as
+`runtime += *(u16*)(definition + 0xE) * 0x4C;` the add computes into the base's
+register; retail computes into the product's register. The original reused the
+`definition` local, dead by then:
+`record = runtime + *(u16*)(record + 0xE) * 0x4C;`. One shared edit
+takes both functions to 100% (180/180 and 256/256 bytes). Rejected: a fresh
+`slot` local or folding into the store operand both collapse to `stwx` (97.3%),
+an int-typed offset chain reorders the loads (99.3%), and reversing the
+operands of `+=` is byte-identical to the compound form.
+
+## The register evidence caught a wrong index update
+
+`fn_8015FF18`'s entry block read `offset = index + 1;` on the negative-value
+path. Retail's `addi` writes the INDEX register, so the original increments
+`index` and derives the scan cursor from it afterwards: `index++;` in the
+block, then `offset = index;` before the while loop. That is a semantic
+difference, not a codegen preference - with the old source the two variables
+disagreed by one for the rest of the function on that path. 208/208 bytes,
+100%. Writing `offset = index;` inside the if instead costs an extra `mr`
+(96.8%).
+
+## The commutative-operand lever extends to fmuls, and where the hoist must sit
+
+`fn_8013DE44` had both `fmuls` encodings reversed. The known comparison lever -
+hoist the call out of the expression so both operands are simple - applies, but
+the hoisted value must be the whole computed subexpression, and the constant
+must sit on the right: `distance = -projection - fn_800ED720(discriminant);
+*result = distance * lbl_80650364;` reaches 264/264, 100%. Hoisting only the
+call result shuffles the float registers instead (99.62%), constant-left with
+the same hoist stays canonicalized (99.70%), and hoisting the constant itself
+makes it live across the call, growing the frame (88.7%).
+
+## An id comparison and a shared conversion constant
+
+`fn_800C65FC` needed two independent fixes. The `cmpw` operand order follows
+from the hoist lever: bind `object_id = fn_80201B54(object);` and write
+`object_id != current`. The remaining relocation row was the s16-to-float
+conversion bias: this unit's pool copy of 0x4330000080000000 must be the shared
+named symbol, so a new externalize rule verifies `@30` against retail data and
+redefines it to `lbl_8064F158`, exactly as `fn_800C59F0` and `fn_800C644C`
+already do. 384/384 bytes, 100%, relocations included.
+
+## A parse cursor is an offset, not a recast pointer
+
+`fn_800AFEC0` walked a buffer with
+`object = (void*)((u32)object + fn(buffer + (u16)(u32)object));` repeated nine
+times, and the final add spilled into a scratch register because the pointer
+local died at its last narrowing. The original is a `u32 offset` advanced with
+`offset += fn(buffer + (u16)offset);` - the compound add computes in the
+accumulator's register, all nine sites, and the code stops pretending the
+running total is a pointer. 364/364 bytes, 100%.
+
+All seven functions verify at 100% with relocations in objdiff, and the
+whole-DOL SHA-1 gate remains `ea24b6af954876ce072562ff39cdb4c81d32be1f`.

--- a/src/game/game_fn_800AFEC0.c
+++ b/src/game/game_fn_800AFEC0.c
@@ -25,6 +25,7 @@ int fn_800AFEC0(void)
     unsigned char* buffer = lbl_8031F7C0;
     void* current;
     void* object;
+    u32 offset;
     void* source;
     float value;
     u32 word;
@@ -38,17 +39,17 @@ int fn_800AFEC0(void)
         memcpy(buffer, source, 12);
         memcpy(buffer + 12, &value, 4);
         memcpy(buffer + 16, &word, 4);
-        object = (void*)(fn_800E5050(buffer + 20) + 20);
-        object = (void*)((u32)object + fn_801F4E38(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_80028D54(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_8016B1D0(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801FABA4(buffer + (u16)(u32)object, 0));
-        object = (void*)((u32)object + fn_801F668C(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_8012BA84(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801E8FAC(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801A8168(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_8011E918(buffer + (u16)(u32)object));
-        fn_801A9A00(buffer + (u16)(u32)object);
+        offset = fn_800E5050(buffer + 20) + 20;
+        offset += fn_801F4E38(buffer + (u16)offset);
+        offset += fn_80028D54(buffer + (u16)offset);
+        offset += fn_8016B1D0(buffer + (u16)offset);
+        offset += fn_801FABA4(buffer + (u16)offset, 0);
+        offset += fn_801F668C(buffer + (u16)offset);
+        offset += fn_8012BA84(buffer + (u16)offset);
+        offset += fn_801E8FAC(buffer + (u16)offset);
+        offset += fn_801A8168(buffer + (u16)offset);
+        offset += fn_8011E918(buffer + (u16)offset);
+        fn_801A9A00(buffer + (u16)offset);
         return 1;
     }
     return 0;

--- a/src/game/game_fn_800C65FC.c
+++ b/src/game/game_fn_800C65FC.c
@@ -17,6 +17,7 @@ extern int fn_801A98F4(int, int);
 void fn_800C65FC(void *object)
 {
     s32 current;
+    s32 object_id;
     s16 x;
     s16 y;
     float ratio;
@@ -25,7 +26,8 @@ void fn_800C65FC(void *object)
         return;
     }
     current = ((s32)fn_80201B44());
-    if (current != ((s32)fn_80201B54(object))) {
+    object_id = ((s32)fn_80201B54(object));
+    if (object_id != current) {
         return;
     }
     if ((lbl_8064D5A8 & 0x3F) != 0 &&

--- a/src/game/game_fn_8012CCF0.c
+++ b/src/game/game_fn_8012CCF0.c
@@ -12,7 +12,7 @@ extern void fn_8012F6E8(void*);
 void fn_8012CCF0(u8* state, int index, Vec3* first, Vec3* second,
                  Vec3* third, int alternate)
 {
-    u8* definition;
+    u8* record;
     u8* entry;
     u8* runtime;
     int bits;
@@ -20,7 +20,7 @@ void fn_8012CCF0(u8* state, int index, Vec3* first, Vec3* second,
     fn_80125ECC(state);
     entry = *(u8**)(*(u8***)(state + 0x240) + index);
     if (entry != 0) {
-        definition = *(u8**)(entry + 4);
+        record = *(u8**)(entry + 4);
         fn_8012BDCC((float*)first, (short*)(entry + 0x54), 6);
         fn_8012BDCC((float*)second, (short*)(entry + 0x60), 6);
         fn_8012BDCC((float*)third, (short*)(entry + 0x66), 6);
@@ -29,8 +29,8 @@ void fn_8012CCF0(u8* state, int index, Vec3* first, Vec3* second,
             lbl_806501D8 != second->z)
             *(u16*)(entry + 0x1C) = 1;
         runtime = *(u8**)(state + 0x160);
-        runtime += *(u16*)(definition + 0xE) * 0x4C;
-        *(u8**)(runtime + 0x48) = entry;
+        record = runtime + *(u16*)(record + 0xE) * 0x4C;
+        *(u8**)(record + 0x48) = entry;
         *(u16*)(entry + 0xA) &= ~0x12;
         bits = alternate ? 0x10 : 2;
         *(u16*)(entry + 0xA) |= bits;

--- a/src/game/game_fn_8012CDF0.c
+++ b/src/game/game_fn_8012CDF0.c
@@ -11,7 +11,7 @@ extern void fn_8012BE78(const float*, short*);
 #pragma use_lmw_stmw on
 void fn_8012CDF0(u8* state, int index, FourWords value, int alternate)
 {
-    u8* definition;
+    u8* record;
     u8* entry;
     u8* runtime;
     int bits;
@@ -20,7 +20,7 @@ void fn_8012CDF0(u8* state, int index, FourWords value, int alternate)
     fn_80125ECC(state);
     entry = *(u8**)(*(u8***)(state + 0x240) + index);
     if (entry != 0) {
-        definition = *(u8**)(entry + 4);
+        record = *(u8**)(entry + 4);
         fn_8012BE78((float*)&value, (short*)(entry + 0x6C));
         zero = lbl_806501D8;
         *(float*)(entry + 0x84) = zero;
@@ -28,8 +28,8 @@ void fn_8012CDF0(u8* state, int index, FourWords value, int alternate)
         *(u32*)(entry + 0x8C) = 0;
         *(u16*)(entry + 0x24) = 0;
         runtime = *(u8**)(state + 0x160);
-        runtime += *(u16*)(definition + 0xE) * 0x4C;
-        *(u8**)(runtime + 0x48) = entry;
+        record = runtime + *(u16*)(record + 0xE) * 0x4C;
+        *(u8**)(record + 0x48) = entry;
         *(u16*)(entry + 0xA) &= ~9;
         bits = alternate ? 8 : 1;
         *(u16*)(entry + 0xA) |= bits;

--- a/src/game/game_fn_80132D50.c
+++ b/src/game/game_fn_80132D50.c
@@ -17,10 +17,9 @@ void fn_80132D50(void)
     Runtime* runtime;
 
     runtime = &lbl_8030F540;
-    i = 0;
     cursor = (char*)runtime;
 
-    do {
+    for (i = 0; i < 5; i++) {
         mask = 1 << i;
         if ((s8)runtime->active_mask & mask) {
             void* object = *(void**)cursor;
@@ -30,7 +29,6 @@ void fn_80132D50(void)
             *(void**)cursor = 0;
             runtime->active_mask &= ~mask;
         }
-        i++;
         cursor += 0x10;
-    } while (i < 5);
+    }
 }

--- a/src/game/game_fn_8013DE44.c
+++ b/src/game/game_fn_8013DE44.c
@@ -21,9 +21,13 @@ int fn_8013DE44(const Vec3* a, const Vec3* b, const Vec3* c,
     discriminant = projection * projection -
         lbl_80650360 * (fn_80211B44(&delta, &delta) - radius * radius);
     if (discriminant >= lbl_80650350) {
-        *result = lbl_80650364 * (-projection - fn_800ED720(discriminant));
+        float distance;
+
+        distance = -projection - fn_800ED720(discriminant);
+        *result = distance * lbl_80650364;
         if (!alternate && *result < lbl_80650350) {
-            *result = lbl_80650364 * (-projection + fn_800ED720(discriminant));
+            distance = -projection + fn_800ED720(discriminant);
+            *result = distance * lbl_80650364;
         }
         return 1;
     }

--- a/src/game/game_fn_8015FF18.c
+++ b/src/game/game_fn_8015FF18.c
@@ -16,9 +16,10 @@ int fn_8015FF18(int* values, int target, int position, int* cursor)
     value = values[offset];
     if (value < 0) {
         position -= value;
-        offset = index + 1;
+        index++;
     }
 
+    offset = index;
     while (values[offset] > target) {
         --offset;
         --position;


### PR DESCRIPTION
## Progress

This PR raises matched code from 28.24% to 28.31% (4265 to 4272 of 8216
functions, 4499 to 4506 of 6088 objects). It adds 7 matched functions and
1,784 matched code bytes. These are seven of the remaining Tier 2 functions
from #4, on top of the seven in #6. All seven sit below the frontier - the
highest is `fn_800C65FC`, against `next_target` 0x801B86C0.

## Current behavior

All seven are NonMatching, each two instructions from retail.

| Function | Bytes | objdiff | divergence |
| --- | ---: | ---: | --- |
| `fn_80132D50` | 128 | 99.6250% | two loop-invariant constants hoisted in swapped order |
| `fn_8012CDF0` | 180 | 99.7778% | slot-pointer sum lands in the base's register, retail uses the product's |
| `fn_8012CCF0` | 256 | 99.8438% | same two instructions as `fn_8012CDF0` |
| `fn_8015FF18` | 208 | 99.8077% | entry-path increment writes the offset register, retail writes index |
| `fn_800C65FC` | 384 | 99.8438% | one `cmpw` operand order, plus a pooled double where retail names `lbl_8064F158` |
| `fn_8013DE44` | 264 | 99.6970% | two `fmuls` operand orders |
| `fn_800AFEC0` | 364 | 99.8901% | final accumulator add spills to r0, retail adds in place |

## New behavior

All seven are Matching, 100% on the canonical basis and under
`function_reloc_diffs=name_address`, 86 relocation sites in total, sizes exact.

## How

- **`fn_8015FF18`** - the old source was wrong, not just misshapen. Retail's
  `addi` writes the index register, so the entry block is `index++` followed by
  `offset = index;` before the while loop. The committed source bumped only
  `offset`, leaving `index` stale by one on the negative-value path for the
  rest of the function. Writing `offset = index;` inside the if instead costs
  an extra `mr` (96.83%).
- **`fn_80132D50`** - rewrite the `do { ... } while (i < 5);` as
  `for (i = 0; i < 5; i++)` with the cursor advance kept in the body. The loop
  form flips the order the two hoisted constants materialize and changes
  nothing else. A pointer-typed zero, swapped init statements, and routing the
  zero through the object local are all byte-neutral.
- **`fn_8012CDF0` and `fn_8012CCF0`** - one shared edit. The sum must land in
  the product's register, so the original reused a local that is dead by then:
  `record = runtime + *(u16*)(record + 0xE) * 0x4C;` (`record` holds the
  entry's definition record first, then its runtime slot). A fresh local or
  folding into the store operand both collapse to `stwx` (97.33%); compound
  `+=` computes into the base's register (byte-identical to current); an
  int-typed offset chain reorders the loads (99.33%).
- **`fn_8013DE44`** - the #5 hoist lever extends to `fmuls`, with two
  constraints: hoist the whole computed subexpression, and put the constant on
  the right. `distance = -projection - fn_800ED720(discriminant);
  *result = distance * lbl_80650364;`. Constant-left with the same hoist stays
  canonicalized (99.70%); hoisting only the call result shuffles the float
  registers (99.62%); hoisting the constant makes it live across the call and
  grows the frame (88.68%); the plain inline flip is byte-identical.
- **`fn_800C65FC`** - two independent fixes. The `cmpw` is the #5 lever:
  `object_id = fn_80201B54(object);` then `object_id != current`
  (`current != object_id` keeps the wrong order). The relocation row is the
  s16-to-float conversion bias: a new externalize rule verifies this unit's
  pooled `0x4330000080000000` against retail data and redefines `@30` to the
  shared `lbl_8064F158`, exactly as `fn_800C59F0` (@8) and `fn_800C644C` (@15)
  already do. The names follow existing tree usage: `current` for
  `fn_80201B44` as in `game_fn_80097014.c`, `object_id` for `fn_80201B54` as
  in `game_fn_80058154.c`.
- **`fn_800AFEC0`** - the parse cursor is a `u32 offset` advanced with
  `offset += fn(buffer + (u16)offset);`, not a `void*` reassigned through
  casts. The compound add computes in the accumulator's register at all nine
  sites; the cast-chain form dies at its last narrowing and spills the final
  sum to r0.

## Testing

objdiff reports 100% for all seven, relocations included, and again under
`function_reloc_diffs=name_address`, with sizes exact. The full build passes
and the DOL SHA-1 is unchanged (`ea24b6af954876ce072562ff39cdb4c81d32be1f`).
The aggregate moved by exactly seven functions and seven objects.

## Other

Two negatives that cut across the set, recorded so nobody repeats them:

- Flipping commutative operands in place never moves the encoding:
  `fn_8013DE44`'s inline flip and `fn_8012CDF0`'s reversed `+=` are both
  byte-identical to their originals. The order becomes controllable only
  after the hoist, consistent with what #4 recorded for the Tier 1 `cmpw`
  family.
- `fn_800C65FC`'s `@30` pool double comes from the compiler's s16-to-float
  lowering, not from any expression in the source, so the reference cannot
  be redirected to `lbl_8064F158` by a source change; repointing the symbol
  after compilation is the only route.
