### PR TITLE
Match seven extern-qualifier functions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1362,6 +1362,15 @@ config.custom_build_rules = [
         "description": "EXTERNALIZE $in",
     },
     {
+        "name": "globalize_game_8002B748_bias",
+        "command": (
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@59=lbl_8064E038 "
+            "--globalize-symbol=lbl_8064E038 $in && touch $out"
+        ),
+        "description": "GLOBALIZE $in",
+    },
+    {
         "name": "externalize_game_800272B4_bias",
         "command": (
             "python3 tools/externalize_elf_symbol.py $in @29 && "
@@ -3288,6 +3297,11 @@ config.custom_build_steps = {
             "inputs": [f"build/{VERSION}/src/game/game_fn_8002F428.o"],
         },
         {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8002B748.globalized"],
+            "rule": "globalize_game_8002B748_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8002B748.o"],
+        },
+        {
             "outputs": [f"build/{VERSION}/src/game/game_fn_800272B4.externalized"],
             "rule": "externalize_game_800272B4_bias",
             "inputs": [f"build/{VERSION}/src/game/game_fn_800272B4.o"],
@@ -4509,12 +4523,8 @@ config.libs = [
             Object(Matching, "game/game_fn_8002B650.c"),
             Object(Matching, "game/game_fn_8002B688.c"),
             Object(Matching, "game/game_fn_8002B6B0.c"),
-            # 96.79612%: exact 824-byte real-C reconstruction; the remaining
-            # differences are confined to scheduling two global loads in the
-            # final call setup. All 30 relocation targets/types agree and
-            # 28/30 sites are equal; its owned sdata2 constant is 100%.
             Object(
-                NonMatching,
+                Matching,
                 "game/game_fn_8002B748.c",
                 extra_cflags=["-use_lmw_stmw on"],
             ),
@@ -5231,7 +5241,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_80066888.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80066A0C.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80066AEC.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_80066BB8.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_80066BB8.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80066D04.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80066D80.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_80066E78.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -5284,7 +5294,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_8006B21C.c"),
     Object(Matching, "game/game_fn_8006B364.c"),
     Object(NonMatching, "game/game_fn_8006B40C.c"),
-    Object(NonMatching, "game/game_fn_8006B488.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8006B488.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_8006B620.c"),
     Object(NonMatching, "game/game_fn_8006B70C.c"),
     Object(Matching, "game/game_fn_8006B804.c"),
@@ -5387,7 +5397,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_800741E8.c"),
     Object(Matching, "game/game_fn_80074310.c"),
     Object(Matching, "game/game_fn_80074440.c"),
-    Object(NonMatching, "game/game_fn_80074580.c"),
+    Object(Matching, "game/game_fn_80074580.c"),
     Object(NonMatching, "game/game_fn_800746CC.c"),
     Object(NonMatching, "game/game_fn_800747CC.c"),
     Object(NonMatching, "game/game_fn_80074864.c"),
@@ -5550,7 +5560,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_8008DBA8.c"),
     Object(Matching, "game/game_fn_8008DD24.c"),
     Object(NonMatching, "game/game_fn_8008DD78.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_8008DF64.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8008DF64.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008E078.c"),
     Object(NonMatching, "game/game_fn_8008E110.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_8008E294.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -5984,7 +5994,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800BB1EC.c"),
             Object(Matching, "game/game_fn_800BB3F8.c"),
             Object(Matching, "game/game_fn_800BB450.c"),
-            Object(NonMatching, "game/game_fn_800BB4C4.c"),
+            Object(Matching, "game/game_fn_800BB4C4.c"),
             Object(NonMatching, "game/game_fn_800BB5C4.c"),
             Object(Matching, "game/game_fn_800BB6A0.c"),
             Object(NonMatching, "game/game_fn_800BB7A8.c"),
@@ -6288,7 +6298,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800DA110.c"),
             Object(Matching, "game/game_fn_800DA1D4.c"),
             Object(Matching, "game/game_fn_800DA278.c"),
-            Object(NonMatching, "game/game_fn_800DA308.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_800DA308.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_800DA400.c"),
             Object(Matching, "game/game_fn_800DAFA8.c"),
             Object(NonMatching, "game/game_fn_800DAFCC.c"),

--- a/docs/matching.md
+++ b/docs/matching.md
@@ -524,3 +524,25 @@ running total is a pointer. 364/364 bytes, 100%.
 
 All seven functions verify at 100% with relocations in objdiff, and the
 whole-DOL SHA-1 gate remains `ea24b6af954876ce072562ff39cdb4c81d32be1f`.
+
+## External object qualifiers affect first-load scheduling
+
+MWCC uses the qualifiers on an external object's declaration when scheduling
+its first load, even when the represented type, width, and storage are
+unchanged. Adding `const` to the scalar declarations in `fn_8002B748`,
+`fn_80066BB8`, and `fn_800BB4C4` moves their loads into the retail order.
+Conversely, removing `const` from the aggregate declarations in
+`fn_8006B488`, `fn_80074580`, `fn_8008DF64`, and `fn_800DA308` reproduces the
+retail aggregate-copy schedule. The previous declarations score 96.79612%,
+95.12048%, 90.625%, 92.15686%, 90.36144%, 94.202896%, and 93.548386%,
+respectively; no control flow, local lifetime, or compiler flag changes are
+needed.
+
+MWCC emits the `lbl_8064E038` bytes in `fn_8002B748` under the local name
+`@59`. Its post-compile rule retains `.sdata2`, renames the symbol, and
+globalizes it so other objects can resolve `lbl_8064E038`. After this rename,
+objdiff reports 824/824, 332/332, 408/408,
+332/332, 276/276, 256/256, and 248/248 bytes at 100% under
+`function_reloc_diffs=name_address`, with 30, 8, 19, 15, 21, 10, and 13
+relocations on both bases. The whole-DOL SHA-1 remains
+`ea24b6af954876ce072562ff39cdb4c81d32be1f`.

--- a/src/game/game_fn_8002B748.c
+++ b/src/game/game_fn_8002B748.c
@@ -26,7 +26,7 @@ typedef struct EffectState {
 
 extern void* lbl_8064C4E0;
 extern volatile s32 lbl_8064D18C;
-extern volatile float lbl_8064E034;
+extern const volatile float lbl_8064E034;
 extern double lbl_8064E038;
 
 extern int fn_80200C10(void *);

--- a/src/game/game_fn_80066BB8.c
+++ b/src/game/game_fn_80066BB8.c
@@ -3,7 +3,7 @@ typedef float f32;
 
 typedef struct Vec3 { f32 x, y, z; } Vec3;
 
-extern f32 lbl_8064E6DC;
+extern const f32 lbl_8064E6DC;
 extern f32 lbl_8064E6F0;
 extern f32 lbl_8064E6D4;
 extern f32 lbl_8064E6F4;

--- a/src/game/game_fn_8006B488.c
+++ b/src/game/game_fn_8006B488.c
@@ -12,7 +12,7 @@ typedef struct Entry {
     u8 rest[0x1C];
 } Entry;
 
-extern const Descriptor lbl_802390B4;
+extern Descriptor lbl_802390B4;
 extern Entry *lbl_8064C8D4;
 extern void *lbl_80243F74[];
 extern s32 fn_8006B620(s32 value);

--- a/src/game/game_fn_80074580.c
+++ b/src/game/game_fn_80074580.c
@@ -20,13 +20,10 @@ extern void fn_8017AB08(const Vec3 *, Vec3 *);
 extern void fn_80211A48(const Vec3 *, const Vec3 *, Vec3 *);
 extern void fn_80211AAC(const Vec3 *, Vec3 *);
 extern void fn_80211A90(const Vec3 *, Vec3 *, float);
-extern const Vec3 lbl_80239194;
+extern Vec3 lbl_80239194;
 extern const float lbl_8064E894;
 extern const float lbl_8064E898;
 
-/* NonMatching: behavior-complete vector routing. Retail and base have equal
- * size and relocations; only MWCC's scheduling of four callee-saved setup
- * instructions around the constant-vector load remains different. */
 int fn_80074580(void *object, void *other, Vec3 *position, State *state,
                 Vec3 *result)
 {

--- a/src/game/game_fn_8008DF64.c
+++ b/src/game/game_fn_8008DF64.c
@@ -4,7 +4,7 @@ typedef struct Vec8008DF64 {
     float z;
 } Vec8008DF64;
 
-extern const volatile Vec8008DF64 lbl_80239648;
+extern volatile Vec8008DF64 lbl_80239648;
 extern int lbl_8064D18C;
 extern int lbl_8064C578;
 
@@ -33,8 +33,6 @@ typedef struct Data8008DF64 {
     }* value8C;
 } Data8008DF64;
 
-/* NonMatching: behavior-complete, size-exact C; aggregate loads are scheduled
- * into the prologue differently. */
 void fn_8008DF64(void* object, void* resource)
 {
     Vec8008DF64 position;

--- a/src/game/game_fn_800BB4C4.c
+++ b/src/game/game_fn_800BB4C4.c
@@ -15,7 +15,7 @@ extern void *fn_801DA3B0(void *, unsigned int, void *, void *, void *, int,
 extern void *fn_800CD458(void *, unsigned int, int, void *, void *, void *,
                         void *);
 extern void fn_8020104C(int, void*, void*, int, float);
-extern float lbl_8064F0C4;
+extern const float lbl_8064F0C4;
 
 unsigned short fn_800BB4C4(void *input, void *object)
 {

--- a/src/game/game_fn_800DA308.c
+++ b/src/game/game_fn_800DA308.c
@@ -11,7 +11,7 @@ typedef struct Vec4 {
     float w;
 } Vec4;
 
-extern const Vec3 lbl_80239988;
+extern Vec3 lbl_80239988;
 extern float lbl_8064F420;
 
 extern void fn_8012CEA4(void *, int, Vec4 *);


### PR DESCRIPTION
## Progress

This raises matched code from 29.10% to 29.21%: 4369 to 4376 of 8216 functions and 4601 to 4608 of 6098 objects. It adds 2,676 matched code bytes.

## Current behavior

These seven functions are marked `NonMatching`. Their previous objdiff instruction scores were:

| Function | Score |
| --- | ---: |
| `fn_8002B748` | 96.79612% |
| `fn_80066BB8` | 95.12048% |
| `fn_8006B488` | 92.15686% |
| `fn_80074580` | 90.36144% |
| `fn_8008DF64` | 94.202896% |
| `fn_800BB4C4` | 90.625% |
| `fn_800DA308` | 93.548386% |

## New behavior

All seven functions are marked `Matching` and reproduce their target instructions and relocations.

## How

- Add `const` to three scalar external declarations.
- Remove `const` from four aggregate external declarations.
- MWCC emits the matching `lbl_8064E038` data in `fn_8002B748` under the local symbol `@59`. Its post-compile rule retains `.sdata2`, renames the symbol to `lbl_8064E038`, and makes it global so references from other objects resolve.
- Document the matching behavior in `docs/matching.md`.

## Testing

Explicit objdiff comparison used `function_reloc_diffs=name_address` on both bases:

| Function | Bytes | Relocation count | Instruction match | Relocation match |
| --- | ---: | ---: | ---: | ---: |
| `fn_8002B748` | 824 | 30 | 100.0000% | 100.0000% |
| `fn_80066BB8` | 332 | 8 | 100.0000% | 100.0000% |
| `fn_8006B488` | 408 | 19 | 100.0000% | 100.0000% |
| `fn_80074580` | 332 | 15 | 100.0000% | 100.0000% |
| `fn_8008DF64` | 276 | 21 | 100.0000% | 100.0000% |
| `fn_800BB4C4` | 256 | 10 | 100.0000% | 100.0000% |
| `fn_800DA308` | 248 | 13 | 100.0000% | 100.0000% |

- Clean full build passed.
- `build/GEDE01/main.dol` SHA-1: `ea24b6af954876ce072562ff39cdb4c81d32be1f`
- Aggregate change: +7 matched functions, +7 matched objects, and +2,676 matched code bytes.
- `python3 tools/legal_audit.py` passed for 9,771 files.
- `git diff --check` passed.

## Other

### Approaches that did not work

- Keeping the original declaration qualifiers produced the instruction scores listed under **Current behavior**, ranging from 90.36144% to 96.79612%.
- Variants using register copies, split initializers, named call-result variables, reversed operand order, compound expressions, rewritten boolean expressions, and different pointer/indexing forms were tested across these functions. None produced an exact match.
- In `fn_80074580`, explicit `register` variables still left four setup instructions in a different order.
- `fn_8008DF64` already had the correct behavior and code size, but MWCC scheduled its global-structure loads differently.
- `fn_800BB4C4` was investigated as a local-structure stack-layout problem but remained unmatched.
- `fn_8002B748` did not work with the `.sdata2` externalization used by the other referencing objects because that rule removes the emitted copy. The retained rule keeps the data, renames MWCC's local symbol `@59` to `lbl_8064E038`, and makes it global.

The accepted changes do not alter control flow, local-variable lifetimes, pragmas, or compiler settings.
