### PR TITLE
Match eight audio functions with per-object compiler settings

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3794,6 +3794,11 @@ if args.debug:
 else:
     cflags_base.append("-DNDEBUG=1")
 
+
+def cflags_with_optimization(optimization):
+    return [optimization if flag == "-O4,p" else flag for flag in cflags_base]
+
+
 Matching = True
 NonMatching = False
 Equivalent = config.non_matching
@@ -9637,14 +9642,14 @@ config.libs = [
             Object(Matching, "game/game_fn_801A98F4.c", extra_cflags=["-schedule off"]),
             Object(Matching, "game/game_fn_801A9964.c"),
             Object(Matching, "game/game_fn_801A9984.c", extra_cflags=["-schedule off"]),
-            Object(NonMatching, "game/game_fn_801A99B4.c"),
+            Object(Matching, "game/game_fn_801A99B4.c", cflags=cflags_with_optimization("-O1,p")),
             Object(Matching, "game/game_fn_801A9A00.c"),
             Object(Matching, "game/game_fn_801A9A20.c"),
             Object(NonMatching, "game/game_fn_801A9A40.c"),
             Object(Matching, "game/game_fn_801A9B28.c"),
             Object(Matching, "game/game_fn_801A9B30.c"),
             Object(NonMatching, "game/game_fn_801A9B38.c", extra_cflags=["-schedule off"]),
-            Object(NonMatching, "game/game_fn_801A9B94.c", extra_cflags=["-schedule off"]),
+            Object(Matching, "game/game_fn_801A9B94.c", cflags=cflags_with_optimization("-O1,p")),
             Object(Matching, "game/game_fn_801A9C78.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801A9CDC.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801A9DCC.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
@@ -9742,7 +9747,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801AE530.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AE5DC.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801AE6B0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801AE91C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801AE91C.c", cflags=cflags_with_optimization("-O3,p")),
             Object(Matching, "game/game_fn_801AEA78.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AEAE0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AEB74.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
@@ -9813,7 +9818,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801B19BC.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B19D8.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B1A1C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801B1B0C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801B1B0C.c", cflags=cflags_with_optimization("-O3")),
             Object(NonMatching, "game/game_fn_801B1BA0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B2348.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B2380.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
@@ -9822,14 +9827,14 @@ config.libs = [
             Object(Matching, "game/game_fn_801B243C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B2444.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801B244C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801B2528.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801B2528.c", mw_version="GC/1.2.5n"),
             Object(NonMatching, "game/game_fn_801B261C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801B2748.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801B2748.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B2818.c", extra_cflags=["-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801B2878.c", extra_cflags=["-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801B2878.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801B2914.c", extra_cflags=["-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801B2980.c", extra_cflags=["-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801B3470.c", mw_version="GC/1.2.5n", extra_cflags=["-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801B3470.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B3558.c", mw_version="GC/1.2.5n", extra_cflags=["-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801B35BC.c", mw_version="GC/1.2.5n", extra_cflags=["-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801B3770.c", mw_version="GC/1.2.5n", extra_cflags=["-opt nopeephole"]),

--- a/docs/matching.md
+++ b/docs/matching.md
@@ -524,3 +524,42 @@ running total is a pointer. 364/364 bytes, 100%.
 
 All seven functions verify at 100% with relocations in objdiff, and the
 whole-DOL SHA-1 gate remains `ea24b6af954876ce072562ff39cdb4c81d32be1f`.
+
+## Per-object compiler settings in the audio code
+
+Eight audio functions require compiler settings different from the game
+library defaults. `fn_801A99B4` and `fn_801A9B94` use GC/1.3 `-O1,p`,
+`fn_801AE91C` uses GC/1.3 `-O3,p`, and `fn_801B1B0C` uses GC/1.3 `-O3`.
+`fn_801B2528`, `fn_801B2748`, `fn_801B2878`, and `fn_801B3470` use
+GC/1.2.5n with the normal game flags. `fn_801B2748` and `fn_801B3470` also
+require `-Cpp_exceptions on` to reproduce their `extab` and `extabindex`
+sections. The per-object optimization lists replace `-O4,p`; appending a
+second optimization flag does not reproduce the verified compiler invocations.
+
+The settings were found by sweeping the 35 unmatched audio units that carried
+`-schedule off` or `-opt nopeephole` overrides across GC/1.3 and GC/1.2.5n at
+`-O1` through `-O4,p`, followed by the `,p` variants and GC/1.3.2. The existing
+source for `fn_801B1B0C` matches unchanged at GC/1.3 `-O3`. The other seven
+also need small source corrections: named call-result locals in
+`fn_801A9B94`; the selected-channel width and child-entry lifetime in
+`fn_801AE91C`; a signed declaration in `fn_801A99B4`; assign-in-condition
+loads and direct list indexing in `fn_801B2528` and `fn_801B2748`; the volatile
+post-increment expression in `fn_801B2878`; and a named command-value local in
+`fn_801B3470`.
+
+The unsuccessful intermediate results were retained as evidence. The compiler
+setting alone reached 99.5% for `fn_801A9B94`, 96.7% for `fn_801AE91C`, 98.2%
+for `fn_801B2528`, 94.8% for `fn_801B2748`, 96.5% for `fn_801B2878`, and 93.8%
+for `fn_801B3470`. Flipping the multiply operands in `fn_801A9B94` was worse.
+For `fn_801A99B4`, locals of different widths, an inverted condition, and a
+modulo expression did not produce the record-form mask instruction. GC/1.3
+did not emit the retail prologue used by `fn_801B2748`; GC/1.2.5n did. Keeping
+the old scheduling or peephole overrides left different branch chains, and
+other optimization levels did not complete `fn_801B3470`. For `fn_801B2878`,
+a separate counter local and the attempted addi-zero pointer-copy forms did not
+match; the direct volatile post-increment did.
+
+Objdiff reports 100% for all eight functions under
+`function_reloc_diffs=name_address`: 76, 228, 348, 148, 244, 208, 156, and
+232 code bytes respectively, with 9, 4, 11, 8, 7, 9, 8, and 8 matching
+relocations.

--- a/src/game/game_fn_801A99B4.c
+++ b/src/game/game_fn_801A99B4.c
@@ -1,6 +1,6 @@
 typedef unsigned int u32;
 
-extern volatile u32 lbl_8064D5A8;
+extern volatile int lbl_8064D5A8;
 
 extern void fn_801A9CDC(void);
 extern void fn_801AC0FC(void);

--- a/src/game/game_fn_801A9B94.c
+++ b/src/game/game_fn_801A9B94.c
@@ -9,10 +9,13 @@ u8 fn_801A9B94(u8 value, int mode)
     int scale;
     int result;
     int clamped;
+    int base;
+    int factor;
 
     if (mode == 3) {
-        scale = fn_801A9B38();
-        scale = fn_801A9B28() * scale / 100;
+        base = fn_801A9B38();
+        factor = fn_801A9B28();
+        scale = factor * base / 100;
     } else if (mode == 2) {
         scale = fn_801A9B30();
     } else {

--- a/src/game/game_fn_801AE91C.c
+++ b/src/game/game_fn_801AE91C.c
@@ -30,8 +30,9 @@ void fn_801AE91C(u32 id, u8 type, int channels, int rate)
     u32 index;
     Entry* entry;
     u32 format;
-    u8 selected_channels;
     u8 selected_rate;
+    u32 selected_channels;
+    Entry* child;
 
     fn_801ADC08();
     index = fn_801ADAF8(id_arg);
@@ -40,7 +41,7 @@ void fn_801AE91C(u32 id, u8 type, int channels, int rate)
         if (channels_arg == -1) {
             selected_channels = entry->channels;
         } else {
-            selected_channels = channels_arg;
+            selected_channels = (u8)channels_arg;
         }
         if (rate_arg == -1) {
             selected_rate = entry->rate;
@@ -56,14 +57,16 @@ void fn_801AE91C(u32 id, u8 type, int channels, int rate)
 
         if (entry->first != 0) {
             entry->first->type = type;
-            format = fn_801A9B94(entry->first->type, 2);
-            fn_801BA94C(entry->first->stream, format, entry->first->channels,
-                        entry->first->rate, 0, 0);
+            child = entry->first;
+            format = fn_801A9B94(child->type, 2);
+            fn_801BA94C(entry->first->stream, format, child->channels,
+                        child->rate, 0, 0);
         } else if (entry->second != 0) {
             entry->second->type = type;
-            format = fn_801A9B94(entry->second->type, 2);
-            fn_801BA94C(entry->second->stream, format, entry->second->channels,
-                        entry->second->rate, 0, 0);
+            child = entry->second;
+            format = fn_801A9B94(child->type, 2);
+            fn_801BA94C(entry->second->stream, format, child->channels,
+                        child->rate, 0, 0);
         }
     }
     fn_801ADBC0();

--- a/src/game/game_fn_801B2528.c
+++ b/src/game/game_fn_801B2528.c
@@ -27,11 +27,11 @@ extern Node* lbl_8064D384;
 
 Node* fn_801B2528(int value, u8 type)
 {
-    Node* node = lbl_8064D384;
+    Node* node;
     Node* current;
     Node* previous;
 
-    if (node != 0) {
+    if ((node = lbl_8064D384) != 0) {
         if ((lbl_8064D384 = node->next) != 0) {
             lbl_8064D384->prev = 0;
         }

--- a/src/game/game_fn_801B2748.c
+++ b/src/game/game_fn_801B2748.c
@@ -15,22 +15,19 @@ extern void fn_801B80D8(void*);
 
 void fn_801B2748(void)
 {
-    unsigned int list_index;
-    unsigned int list_offset = 0;
     Node* node;
     Node* next;
+    unsigned int i;
 
-    for (list_index = 0; list_index < 2; list_index++, list_offset += 4) {
-        node = *(Node**)((unsigned char*)lbl_8064D380 + 0xE64 + list_offset);
+    for (i = 0; i < 2; i++) {
+        node = lbl_8064D380->lists[i];
         while (node != 0) {
             next = node->next;
             fn_801B80D8(node->object);
-            *(Node**)((unsigned char*)lbl_8064D380 + 0xE64 + list_offset) = node->next;
-            if (*(Node**)((unsigned char*)lbl_8064D380 + 0xE64 + list_offset) != 0) {
-                (*(Node**)((unsigned char*)lbl_8064D380 + 0xE64 + list_offset))->prev = 0;
+            if ((lbl_8064D380->lists[i] = node->next) != 0) {
+                lbl_8064D380->lists[i]->prev = 0;
             }
-            node->next = lbl_8064D380->lists[2];
-            if (lbl_8064D380->lists[2] != 0) {
+            if ((node->next = lbl_8064D380->lists[2]) != 0) {
                 lbl_8064D380->lists[2]->prev = node;
             }
             lbl_8064D380->lists[2] = node;

--- a/src/game/game_fn_801B2878.c
+++ b/src/game/game_fn_801B2878.c
@@ -22,15 +22,12 @@ unsigned int fn_801B2878(int index)
     Node* second;
     unsigned int value;
     Node* node;
-    unsigned int current;
 
     first = lbl_8064D39C;
     second = lbl_8064D398;
 
     do {
-        current = lbl_8064D390;
-        lbl_8064D390 = current + 1;
-        value = current;
+        value = lbl_8064D390++;
         lbl_8064D390 = __rlwinm(lbl_8064D390, 0, 1, 31);
 
         node = first;

--- a/src/game/game_fn_801B3470.c
+++ b/src/game/game_fn_801B3470.c
@@ -30,6 +30,7 @@ void fn_801B3470(u8 index)
 {
     Channel* channel;
     Command* command;
+    u32 value;
 
     channel = &lbl_8064D380->channels[index];
     if (channel->active != 0) {
@@ -39,8 +40,9 @@ void fn_801B3470(u8 index)
             }
 
             if (*(u32*)((u8*)lbl_8064D380->flags_object + 0x10) & 0x40000000) {
-                channel->position = command->value;
-                fn_801B5B20(command->value >> 10, lbl_8064D388, index);
+                value = command->value;
+                channel->position = value;
+                fn_801B5B20(value >> 10, lbl_8064D388, index);
             } else {
                 fn_801B5B20(command->value, lbl_8064D388, index);
                 channel->position = channel->cursor->value << 10;


### PR DESCRIPTION
## Progress

This raises matched code from 29.10% to 29.17%: 669,404 to 671,044 of
2,300,692 code bytes. It raises matched functions from 4,369 to 4,377 of
8,216 and matched objects from 4,601 to 4,609 of 6,098.

## Current behavior

These eight audio functions were registered as non-matching. Their existing
per-object compiler overrides or the game library defaults did not reproduce
the retail objects.

## New behavior

All eight functions are registered as matching with explicit per-object
compiler settings. Together they add eight matching functions, eight matching
objects, and 1,640 matching code bytes.

## How

The four GC/1.3 objects use copies of the game flags with `-O4,p` replaced by
the required optimization level. Four later objects use GC/1.2.5n without the
old scheduling or peephole overrides. Two of those objects enable C++ exception
metadata to reproduce their retail `extab` and `extabindex` sections.

| Function | Compiler settings | Source correction | Bytes | Relocations |
| --- | --- | --- | ---: | ---: |
| `fn_801A99B4` | GC/1.3 `-O1,p` | Declare the masked global as signed. | 76 | 9 |
| `fn_801A9B94` | GC/1.3 `-O1,p` | Keep the two call results in named locals. | 228 | 4 |
| `fn_801AE91C` | GC/1.3 `-O3,p` | Preserve the selected-channel width and child-entry lifetime. | 348 | 11 |
| `fn_801B1B0C` | GC/1.3 `-O3` | None; the existing source matches. | 148 | 8 |
| `fn_801B2528` | GC/1.2.5n `-O4,p` | Load the free-list head in the condition. | 244 | 7 |
| `fn_801B2748` | GC/1.2.5n `-O4,p`, exceptions on | Use direct list indexing and assignment conditions. | 208 | 9 |
| `fn_801B2878` | GC/1.2.5n `-O4,p` | Express the volatile counter update as post-increment. | 156 | 8 |
| `fn_801B3470` | GC/1.2.5n `-O4,p`, exceptions on | Keep the command value in a named local. | 232 | 8 |

`docs/matching.md` records the reusable compiler-setting findings and rejected
forms.

## Testing

- Regenerated with `python3 configure.py`.
- Built each affected object and compared its named function with
  `function_reloc_diffs=name_address`.
- All eight functions report 100.0000% instructions, identical code sizes,
  equal relocation counts, and zero strict diff markers.
- A serial full build with `.tools/bin/ninja -j1` completed successfully.
- `build/GEDE01/main.dol` has SHA-1
  `ea24b6af954876ce072562ff39cdb4c81d32be1f`.
- `python3 tools/legal_audit.py` passed.
- `git diff --check` passed.

## Other

### Approaches that did not work

- For `fn_801A99B4`, GC/1.3 `-O1,p` reached 96.8% before the signed
  declaration correction. Locals of different widths, an inverted condition,
  and a modulo expression did not produce the required record-form mask.
  Appending `-O1,p` after the library's `-O4,p`, instead of replacing it,
  reached 94.47369%.
- For `fn_801A9B94`, `-O1,p` reached 99.5% before the named call-result
  locals. Flipping the multiply operands was worse.
- For `fn_801AE91C`, `-O3,p` reached 96.7% before the source corrections.
  The other swept optimization variants did not match.
- For `fn_801B1B0C`, the old scheduling and peephole overrides did not match;
  the existing source matches unchanged at GC/1.3 `-O3`.
- For `fn_801B2528`, the GC/1.2.5n setting alone reached 98.2%. Moving the
  free-list load into the condition produced the required register assignment.
- For `fn_801B2748`, GC/1.2.5n with the corrected flags reached 94.8% before
  the source rewrite. GC/1.3 did not emit the retail prologue, while retaining
  the old scheduling or peephole overrides left different branch chains.
- For `fn_801B2878`, the GC/1.2.5n setting alone reached 96.5%. A separate
  counter local and attempted addi-zero pointer-copy forms did not match; the
  direct volatile post-increment did.
- For `fn_801B3470`, removing `-opt nopeephole` reached 93.8% before adding
  the command-value local. Other optimization levels did not complete it.
- Promoting `fn_801B2748` and `fn_801B3470` without exception metadata matched
  their code but omitted their retail exception-table sections and failed the
  full-DOL gate. Enabling exceptions reproduces those sections.
