### PR TITLE
Match 34 functions with guarded compiler-local data externalization

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -422,9 +422,10 @@ config.custom_build_rules = [
     {
         "name": "externalize_game_80192F54_signed_bias",
         "command": (
-            "python3 tools/externalize_elf_symbol.py $in @34 lbl_80650B18 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @33 lbl_80650B18 "
+            f"orig/{VERSION}/sys/main.dol --require-whole-section && "
             "build/binutils/powerpc-eabi-objcopy "
-            "--redefine-sym=@34=lbl_80650B18 --remove-section=.sdata2 "
+            "--redefine-sym=@33=lbl_80650B18 --remove-section=.sdata2 "
             "--rename-section=.comment=.ignored $in && touch $out"
         ),
         "description": "EXTERNALIZE $in",
@@ -2310,6 +2311,117 @@ config.custom_build_rules = [
     },
 ]
 
+game_section_externalizations = {
+    "8006B0F0": (".rodata", [("@4", "lbl_80239090")]),
+    "8007D4D8": (".sdata2", [("@13", "lbl_8064E9D8")]),
+    "8007F770": (".sdata2", [("@8", "lbl_8064EA48")]),
+    "80088F4C": (".sdata2", [("@25", "lbl_8064EB88")]),
+    "80090004": (".sdata2", [("@15", "lbl_8064EC18")]),
+    "80095D10": (".sdata2", [("@20", "lbl_8064ECD8")]),
+    "800A3180": (".sdata2", [("@11", "lbl_8064EE78")]),
+    "800BB5C4": (".sdata2", [("@9", "lbl_8064F020"), ("@7", "lbl_8064F010")]),
+    "800BB9A4": (".sdata2", [("@8", "lbl_8064F020")]),
+    "800BBAF0": (".sdata2", [("@8", "lbl_8064F020")]),
+    "800D9E10": (".sdata2", [("@15", "lbl_8064F438")]),
+    "8012976C": (".sdata2", [("@12", "lbl_806501A8")]),
+    "8014CA98": (".sdata2", [("@8", "lbl_806504F0")]),
+    "80153A24": (".sdata2", [("@15", "lbl_806505C8"), ("@18", "lbl_806505D0")]),
+    "80174F2C": (".sdata2", [("@17", "lbl_806506A8")]),
+    "8017AC20": (".sdata2", [("@18", "lbl_806508A8")]),
+    "8018680C": (".sdata2", [("@20", "lbl_80650A10")]),
+    "80186F70": (".sdata2", [("@22", "lbl_80650A38")]),
+    "80187BB4": (".sdata2", [("@9", "lbl_80650A48"), ("@12", "lbl_80650A40")]),
+    "8018D400": (
+        ".sdata2",
+        [
+            ("@28", "lbl_80650A70"),
+            ("@26", "lbl_80650A78"),
+            ("@23", "lbl_80650AAC"),
+            ("@24", "lbl_80650AB0"),
+        ],
+    ),
+    "8018E0D8": (".sdata2", [("@11", "lbl_80650A70")]),
+    "8019120C": (".sdata2", [("@6", "lbl_80650B18")]),
+    "801916D0": (".sdata2", [("@23", "lbl_80650B38"), ("@26", "lbl_80650B18")]),
+    "801926EC": (".sdata2", [("@35", "lbl_80650B18")]),
+    "801A2A54": (".sdata2", [("@8", "lbl_80650D20")]),
+    "801A34BC": (".sdata2", [("@14", "lbl_80650D20")]),
+    "801A657C": (".sdata2", [("@8", "lbl_80650DB0")]),
+}
+
+game_jumptable_externalizations = {
+    "8006E53C": [("@26", "jumptable_80244324")],
+    "800CF598": [("@26", "jumptable_802489C4")],
+    "801ACFE8": [("@21", "jumptable_80251748")],
+    "801B1BA0": [
+        ("@188", "jumptable_802520E8"),
+        ("@189", "jumptable_802520C0"),
+    ],
+}
+
+def add_game_externalization_rules(externalizations, rule_suffix, description):
+    for function, (section, mappings) in externalizations.items():
+        guards = []
+        for mapping_index, (local, retail) in enumerate(mappings):
+            guard = (
+                f"python3 tools/externalize_elf_symbol.py $in {local} {retail} "
+                f"orig/{VERSION}/sys/main.dol"
+            )
+            if len(mappings) == 1:
+                guard += " --require-whole-section"
+            elif mapping_index == 0:
+                locals_in_section = ",".join(local for local, _ in mappings)
+                guard += f" --require-section-symbols={locals_in_section}"
+            guards.append(guard)
+        redefinitions = " ".join(
+            f"--redefine-sym={local}={retail}" for local, retail in mappings
+        )
+        config.custom_build_rules.append(
+            {
+                "name": f"externalize_game_{function}_{rule_suffix}",
+                "command": (
+                    " && ".join(guards)
+                    + " && build/binutils/powerpc-eabi-objcopy "
+                    + redefinitions
+                    + f" --remove-section={section} "
+                    + "--rename-section=.comment=.ignored $in && touch $out"
+                ),
+                "description": description,
+            }
+        )
+
+
+add_game_externalization_rules(
+    game_section_externalizations, "constants", "EXTERNALIZE $in"
+)
+add_game_externalization_rules(
+    {
+        function: (".data", mappings)
+        for function, mappings in game_jumptable_externalizations.items()
+    },
+    "jumptables",
+    "EXTERNALIZE JUMPTABLES $in",
+)
+
+config.custom_build_rules.append(
+    {
+        "name": "externalize_game_8009E808_sounds",
+        "command": (
+            "build/binutils/powerpc-eabi-objcopy "
+            "--add-symbol=lbl_8064EDC8=.sdata2:4,global,object $in && "
+            "python3 tools/retarget_elf_relocation.py $in @4 4 "
+            "lbl_8064EDC4 lbl_8064EDC8 4 R_PPC_EMB_SDA21 "
+            f"orig/{VERSION}/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @4 lbl_8064EDC4 "
+            f"orig/{VERSION}/sys/main.dol --require-whole-section && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@4=lbl_8064EDC4 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    }
+)
+
 # A renamed compiler-local symbol must contain the retail value it claims to
 # represent whenever it has a complete, relocation-free file-backed value.
 # Every invocation must map to a retail symbol and DOL. The externalizer rejects
@@ -3807,6 +3919,37 @@ config.custom_build_steps = {
         },
     ]
 }
+
+for function in game_section_externalizations:
+    config.custom_build_steps["post-compile"].append(
+        {
+            "outputs": [
+                f"build/{VERSION}/src/game/game_fn_{function}.externalized"
+            ],
+            "rule": f"externalize_game_{function}_constants",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_{function}.o"],
+        }
+    )
+
+for function in game_jumptable_externalizations:
+    config.custom_build_steps["post-compile"].append(
+        {
+            "outputs": [
+                f"build/{VERSION}/src/game/game_fn_{function}.externalized"
+            ],
+            "rule": f"externalize_game_{function}_jumptables",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_{function}.o"],
+        }
+    )
+
+config.custom_build_steps["post-compile"].append(
+    {
+        "outputs": [f"build/{VERSION}/src/game/game_fn_8009E808.externalized"],
+        "rule": "externalize_game_8009E808_sounds",
+        "inputs": [f"build/{VERSION}/src/game/game_fn_8009E808.o"],
+    }
+)
+
 if args.map:
     config.ldflags.append("-mapunused")
 if args.debug:
@@ -5323,7 +5466,7 @@ config.libs = [
     Object(Matching, "game/game_fn_8006AEA4.c"),
     Object(Matching, "game/game_fn_8006AF20.c"),
     Object(Matching, "game/game_fn_8006B0A0.c"),
-    Object(NonMatching, "game/game_fn_8006B0F0.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8006B0F0.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8006B1C0.c"),
     Object(NonMatching, "game/game_fn_8006B21C.c"),
     Object(Matching, "game/game_fn_8006B364.c"),
@@ -5373,7 +5516,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_8006DEF8.c"),
     Object(Matching, "game/game_fn_8006E3D4.c"),
     Object(Matching, "game/game_fn_8006E3F8.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_8006E53C.c"),
+    Object(Matching, "game/game_fn_8006E53C.c"),
     Object(NonMatching, "game/game_fn_8006E644.c"),
     Object(Matching, "game/game_fn_8006E6EC.c"),
     Object(NonMatching, "game/game_fn_8006E754.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -5488,14 +5631,14 @@ config.libs = [
     Object(Matching, "game/game_fn_8007D2B4.c"),
     Object(Matching, "game/game_fn_8007D3C0.c"),
     Object(Matching, "game/game_fn_8007D4D4.c"),
-    Object(NonMatching, "game/game_fn_8007D4D8.c"),
+    Object(Matching, "game/game_fn_8007D4D8.c"),
     Object(Matching, "game/game_fn_8007D69C.c"),
     Object(NonMatching, "game/game_fn_8007D744.c"),
     Object(Matching, "game/game_fn_8007D834.c"),
     Object(Matching, "game/game_fn_8007D848.c"),
     Object(Matching, "game/game_fn_8007D944.c"),
     Object(Matching, "game/game_fn_8007F650.c"),
-    Object(NonMatching, "game/game_fn_8007F770.c"),
+    Object(Matching, "game/game_fn_8007F770.c"),
     Object(Matching, "game/game_fn_8007FAC0.c"),
     Object(Matching, "game/game_fn_8007FAC8.c"),
     Object(Matching, "game/game_fn_8007FFB4.c"),
@@ -5544,7 +5687,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_80088D04.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_80088E44.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80088F08.c"),
-    Object(NonMatching, "game/game_fn_80088F4C.c"),
+    Object(Matching, "game/game_fn_80088F4C.c"),
     Object(Matching, "game/game_fn_800890F4.c"),
     Object(Matching, "game/game_fn_800891F4.c"),
     Object(Matching, "game/game_fn_800891FC.c"),
@@ -5613,7 +5756,7 @@ config.libs = [
     Object(Matching, "game/game_fn_8008F860.c"),
     Object(Matching, "game/game_fn_8008F890.c"),
     Object(NonMatching, "game/game_fn_8008F960.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_80090004.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_80090004.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80090204.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_800902D0.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8009050C.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -5642,7 +5785,7 @@ config.libs = [
     Object(Matching, "game/game_fn_80095774.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_80095894.c"),
     Object(Matching, "game/game_fn_80095C20.c"),
-    Object(NonMatching, "game/game_fn_80095D10.c"),
+    Object(Matching, "game/game_fn_80095D10.c"),
     Object(NonMatching, "game/game_fn_80095E64.c"),
     Object(Matching, "game/game_fn_80095FDC.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80096208.c"),
@@ -5678,7 +5821,7 @@ config.libs = [
     Object(Matching, "game/game_fn_8009E39C.c"),
     Object(NonMatching, "game/game_fn_8009E4BC.c"),
     Object(Matching, "game/game_fn_8009E710.c"),
-    Object(NonMatching, "game/game_fn_8009E808.c"),
+    Object(Matching, "game/game_fn_8009E808.c"),
     Object(Matching, "game/game_fn_8009EA3C.c"),
     Object(Matching, "game/game_fn_8009EAB0.c"),
     Object(Matching, "game/game_fn_8009EC34.c"),
@@ -5781,7 +5924,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800A30CC.c"),
     Object(Matching, "game/game_fn_800A30F4.c"),
     Object(NonMatching, "game/game_fn_800A3104.c"),
-    Object(NonMatching, "game/game_fn_800A3180.c"),
+    Object(Matching, "game/game_fn_800A3180.c"),
     Object(Matching, "game/game_fn_800A3240.c"),
     Object(Matching, "game/game_fn_800A3274.c"),
     Object(Matching, "game/game_fn_800A32B8.c"),
@@ -6029,13 +6172,13 @@ config.libs = [
             Object(Matching, "game/game_fn_800BB3F8.c"),
             Object(Matching, "game/game_fn_800BB450.c"),
             Object(Matching, "game/game_fn_800BB4C4.c"),
-            Object(NonMatching, "game/game_fn_800BB5C4.c"),
+            Object(Matching, "game/game_fn_800BB5C4.c"),
             Object(Matching, "game/game_fn_800BB6A0.c"),
             Object(NonMatching, "game/game_fn_800BB7A8.c"),
             Object(Matching, "game/game_fn_800BB8AC.c"),
-            Object(NonMatching, "game/game_fn_800BB9A4.c"),
+            Object(Matching, "game/game_fn_800BB9A4.c"),
             Object(Matching, "game/game_fn_800BBA84.c"),
-            Object(NonMatching, "game/game_fn_800BBAF0.c"),
+            Object(Matching, "game/game_fn_800BBAF0.c"),
             Object(Matching, "game/game_fn_800BBBC4.c"),
             Object(Matching, "game/game_fn_800BBC40.c"),
             Object(Matching, "game/game_fn_800BBE04.c"),
@@ -6236,7 +6379,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800CF3D4.c"),
             Object(Matching, "game/game_fn_800CF46C.c"),
             Object(Matching, "game/game_fn_800CF52C.c"),
-            Object(NonMatching, "game/game_fn_800CF598.c"),
+            Object(Matching, "game/game_fn_800CF598.c"),
             Object(Matching, "game/game_fn_800CF8D0.c"),
             Object(Matching, "game/game_fn_800CF904.c"),
             Object(NonMatching, "game/game_fn_800CFA3C.c"),
@@ -6324,7 +6467,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800D9BE0.c"),
             Object(Matching, "game/game_fn_800D9C48.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_800D9D64.c"),
-            Object(NonMatching, "game/game_fn_800D9E10.c"),
+            Object(Matching, "game/game_fn_800D9E10.c"),
             Object(NonMatching, "game/game_fn_800D9F2C.c"),
             Object(NonMatching, "game/game_fn_800D9FE0.c"),
             Object(NonMatching, "game/game_fn_800DA05C.c"),
@@ -7098,7 +7241,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801296E8.c"),
             Object(Matching, "game/game_fn_801296F8.c"),
             Object(Matching, "game/game_fn_80129748.c"),
-            Object(NonMatching, "game/game_fn_8012976C.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8012976C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80129878.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80129928.c"),
             Object(Matching, "game/game_fn_8012998C.c"),
@@ -7561,7 +7704,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8014C8F8.c"),
             Object(Matching, "game/game_fn_8014C988.c"),
             Object(Matching, "game/game_fn_8014C9F4.c"),
-            Object(NonMatching, "game/game_fn_8014CA98.c"),
+            Object(Matching, "game/game_fn_8014CA98.c"),
             Object(Matching, "game/game_fn_8014CB54.c"),
             Object(Matching, "game/game_fn_8014CB90.c"),
             Object(Matching, "game/game_fn_8014CBC0.c"),
@@ -7633,7 +7776,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80153880.c"),
             Object(Matching, "game/game_fn_80153898.c"),
             Object(Matching, "game/game_fn_80153904.c"),
-            Object(NonMatching, "game/game_fn_80153A24.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80153A24.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80153D04.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80153DF0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80153F00.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -8489,7 +8632,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80174EB4.c"),
             # 90.112680% exact-size honest C; callback/constant setup retains
             # five scheduling differences and one local-constant relocation.
-            Object(NonMatching, "game/game_fn_80174F2C.c"),
+            Object(Matching, "game/game_fn_80174F2C.c"),
             Object(Matching, "game/game_fn_80175164.c"),
             Object(Matching, "game/game_fn_801751DC.c"),
             Object(Matching, "game/game_fn_80175244.c"),
@@ -8580,7 +8723,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80179F48.c"),
             Object(Matching, "game/game_fn_80179FE4.c"),
             Object(Matching, "game/game_fn_8017A010.c"),
-            Object(NonMatching, "game/game_fn_8017A12C.c"),
+            Object(Matching, "game/game_fn_8017A12C.c"),
             Object(Matching, "game/game_fn_8017A1C0.c"),
             Object(Matching, "game/game_fn_8017A244.c"),
             Object(Matching, "game/game_fn_8017A284.c"),
@@ -8649,7 +8792,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8017AB08.c"),
             Object(Matching, "game/game_fn_8017ABA0.c"),
             Object(Matching, "game/game_fn_8017ABE0.c"),
-            Object(NonMatching, "game/game_fn_8017AC20.c"),
+            Object(Matching, "game/game_fn_8017AC20.c"),
             Object(Matching, "game/game_fn_8017ACE0.c"),
             Object(Matching, "game/game_fn_8017AD00.c"),
             Object(Matching, "game/game_fn_8017AD7C.c"),
@@ -8964,7 +9107,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801861C4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801865EC.c"),
             Object(NonMatching, "game/game_fn_8018666C.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8018680C.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018680C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80186954.c"),
             Object(Matching, "game/game_fn_801869DC.c"),
             Object(Matching, "game/game_fn_801869E4.c"),
@@ -8975,7 +9118,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80186C88.c"),
             Object(Matching, "game/game_fn_80186D74.c"),
             Object(Matching, "game/game_fn_80186E10.c"),
-            Object(NonMatching, "game/game_fn_80186F70.c"),
+            Object(Matching, "game/game_fn_80186F70.c"),
             Object(Matching, "game/game_fn_801870D0.c"),
             Object(Matching, "game/game_fn_80187120.c"),
             Object(NonMatching, "game/game_fn_801871F0.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -8992,7 +9135,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80187A3C.c"),
             Object(Matching, "game/game_fn_80187A44.c"),
             Object(NonMatching, "game/game_fn_80187A4C.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_80187BB4.c"),
+            Object(Matching, "game/game_fn_80187BB4.c"),
             Object(Matching, "game/game_fn_80187DF4.c"),
             Object(NonMatching, "game/game_fn_80187E40.c"),
             Object(Matching, "game/game_fn_8018807C.c"),
@@ -9065,7 +9208,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8018D160.c"),
             Object(Matching, "game/game_fn_8018D1F0.c"),
             Object(Matching, "game/game_fn_8018D2E0.c"),
-            Object(NonMatching, "game/game_fn_8018D400.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018D400.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018D688.c"),
             Object(Matching, "game/game_fn_8018D724.c"),
             Object(Matching, "game/game_fn_8018D788.c"),
@@ -9073,7 +9216,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_8018D998.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018DC24.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018DE9C.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8018E0D8.c"),
+            Object(Matching, "game/game_fn_8018E0D8.c"),
             Object(Matching, "game/game_fn_8018E1C4.c"),
             Object(Matching, "game/game_fn_8018E230.c"),
             Object(Matching, "game/game_fn_8018E24C.c"),
@@ -9139,12 +9282,12 @@ config.libs = [
             Object(Matching, "game/game_fn_801911F4.c"),
             Object(Matching, "game/game_fn_801911FC.c"),
             Object(Matching, "game/game_fn_80191204.c"),
-            Object(NonMatching, "game/game_fn_8019120C.c"),
+            Object(Matching, "game/game_fn_8019120C.c"),
             Object(Matching, "game/game_fn_80191360.c"),
             Object(NonMatching, "game/game_fn_801913F4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801914D8.c"),
             Object(Matching, "game/game_fn_80191568.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_801916D0.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801916D0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8019197C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80191BA8.c"),
             Object(Matching, "game/game_fn_80191C8C.c"),
@@ -9153,10 +9296,10 @@ config.libs = [
             Object(Matching, "game/game_fn_80191F58.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80192318.c"),
             Object(Matching, "game/game_fn_801925F0.c"),
-            Object(NonMatching, "game/game_fn_801926EC.c"),
+            Object(Matching, "game/game_fn_801926EC.c"),
             Object(NonMatching, "game/game_fn_801929A4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80192E8C.c"),
-            Object(NonMatching, "game/game_fn_80192F54.c"),
+            Object(Matching, "game/game_fn_80192F54.c"),
             Object(NonMatching, "game/game_fn_801931C4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801936FC.c"),
             Object(Matching, "game/game_fn_80193838.c"),
@@ -9385,7 +9528,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801A2540.c"),
             Object(NonMatching, "game/game_fn_801A260C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801A29E0.c"),
-            Object(NonMatching, "game/game_fn_801A2A54.c"),
+            Object(Matching, "game/game_fn_801A2A54.c"),
             Object(Matching, "game/game_fn_801A2AB4.c"),
             Object(NonMatching, "game/game_fn_801A2BCC.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801A2D64.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9394,7 +9537,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801A3200.c"),
             Object(NonMatching, "game/game_fn_801A329C.c"),
             Object(Matching, "game/game_fn_801A3420.c"),
-            Object(NonMatching, "game/game_fn_801A34BC.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801A34BC.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801A35F4.c"),
             Object(NonMatching, "game/game_fn_801A36C0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801A38D0.c"),
@@ -9464,7 +9607,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801A63A0.c"),
             Object(Matching, "game/game_fn_801A6410.c"),
             Object(Matching, "game/game_fn_801A64F8.c"),
-            Object(NonMatching, "game/game_fn_801A657C.c"),
+            Object(Matching, "game/game_fn_801A657C.c"),
             Object(Matching, "game/game_fn_801A65C0.c"),
             Object(Matching, "game/game_fn_801A65E0.c"),
             Object(Matching, "game/game_fn_801A664C.c"),
@@ -9746,7 +9889,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801ACE30.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801ACF80.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801ACFB0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801ACFE8.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801ACFE8.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801AD08C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AD404.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AD46C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
@@ -9858,7 +10001,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801B19D8.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B1A1C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B1B0C.c", cflags=cflags_with_optimization("-O3")),
-            Object(NonMatching, "game/game_fn_801B1BA0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801B1BA0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B2348.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B2380.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801B2410.c", extra_cflags=["-schedule off", "-opt nopeephole"]),

--- a/docs/matching.md
+++ b/docs/matching.md
@@ -605,3 +605,85 @@ Objdiff reports 100% for all eight functions under
 `function_reloc_diffs=name_address`: 76, 228, 348, 148, 244, 208, 156, and
 232 code bytes respectively, with 9, 4, 11, 8, 7, 9, 8, and 8 matching
 relocations.
+
+## A local initializer can share an existing rodata table
+
+`fn_8006B0F0` copies the three values `{0, 2, 3}` to its stack frame before
+iterating over them. Declaring `s32 kinds[3] = {0, 2, 3};` before the state
+lookup reproduces the retail instructions, but MWCC emits the initializer as
+the compiler-local `.rodata` symbol `@4`. The post-compile rule requires `@4`
+to own that entire section, verifies its 12 bytes against the start of the
+existing retail symbol `lbl_80239090`, redefines the symbol, and removes the
+duplicate section. The raw object is 99.51923%; the guarded build edge is
+208/208 bytes and 100% with all eight relocation sites equal.
+
+Modelling the values as an external `Kinds` structure, copying that structure
+after the state lookup, and indexing `kinds.values` produces the same-sized
+function at 57.98077%.
+
+## Compiler-local data must be removed, not only renamed
+
+MWCC emits local constant pools and jump tables even when identical data already exists in
+the retail binary. Renaming the local symbol is sufficient for a strict function diff, but it
+is not sufficient for the linked binary: the object still owns a duplicate data section. The
+post-compile rules therefore verify the local data against the addressed retail symbol,
+redefine references to that symbol, and remove the local section. A single-symbol rule must
+cover the whole section. A multi-symbol rule must name every nonempty symbol in the section;
+the guard rejects overlapping ranges and nonzero bytes outside those ranges.
+
+This distinction matters for jump tables. The first strict pass for `fn_8006E53C`,
+`fn_800CF598`, `fn_801ACFE8`, and `fn_801B1BA0` renamed their tables and reached 100% at the
+function level, but left 476 bytes of duplicate `.data` plus 20 bytes of linker alignment.
+Externalizing the tables and removing those sections restores the retail DOL exactly.
+
+`fn_8009E808` has a separate case: one compiler-local eight-byte `.sdata2` symbol corresponds
+to two adjacent four-byte retail symbols. Its second relocation must first be retargeted from
+the local symbol plus four to the second retail symbol. The retargeting tool requires exactly
+one relocation with the expected type and addend, verifies both four-byte values against the
+retail DOL, and fails without writing if any check differs. Treating the full eight bytes as
+one retail symbol leaves a strict relocation-name difference at 99.9% even though the linked
+address is the same.
+
+The full-link checksum is required in addition to function-level objdiff. It caught the
+duplicate jump-table sections that the function comparison correctly did not score.
+
+## Source forms rejected while matching externalized-data functions
+
+- The earlier source using direct multidimensional `SceneEntry` indexing in
+  `fn_80090004` scores 89.671875% because
+  retail keeps the address of the table's strided `value` column in a saved register. A
+  two-use accessor macro contains that layout calculation, and it is undefined immediately
+  after the function.
+- In `fn_8007D4D8`, passing the packed direction word directly after copying the vector
+  leaves one stack reload and scores 99.0%. Reading the packed word into a named local before
+  the copy keeps it in a register and matches exactly.
+- `fn_801247F8` reaches 100% only by converting a live pointer to an integer and adding it to
+  an integer offset as though the offset were a pointer. Readable pointer-index forms are
+  size-exact at 99.84615%, so this function remains NonMatching.
+- In `fn_80174F2C`, moving the descriptor assignment out of the helper call while using only
+  `opt_common_subs off` produces 556 bytes instead of 568 and scores 96.34507%. Disabling
+  `opt_propagation` as well and storing the script value in a named `u16` preserves the
+  descriptor lifetime and matches exactly with ordinary assignment statements.
+- Declaring `fn_801E8328` variadic in `fn_80153A24` adds two `crclr` instructions, producing
+  744 bytes instead of 736 and 98.91304%. Existing calls use different argument counts, so
+  the retained old-style declaration is consistent with the dispatcher boundary.
+- Two separate walking descriptor pointers in `fn_80153A24` score 95.2%. Keeping the pair in
+  a two-element array reproduces the retail parameter allocation without dummy state.
+- Keeping the second loop index block-scoped in `fn_80186F70` scores 99.40909%. Separate
+  named loop counters, with the second counter function-scoped, match exactly.
+- Signed-byte casts on the three differences in `fn_80187BB4` add `extsb` instructions and
+  score 91.354164%. The byte operands already promote to `int`, so removing the casts is both
+  simpler and exact.
+- Replacing the packed-coordinate stores in `fn_801916D0` with two `memcpy` calls produces
+  716 bytes instead of 684 and 90.34503%. A union with named coordinate and packed-word views
+  expresses both uses without pointer aliasing and matches exactly.
+- Marking the three floating-point globals used by `fn_80192F54` as `const` changes floating
+  register allocation and scores 99.45513%; the non-const declarations match exactly.
+- Reusing and rebasing the input pointer directly in `fn_8019120C` scores 97.61176%. Keeping
+  the input and the rebased working pointer as distinct locals matches exactly.
+- Declaring `lbl_8064D2FC` signed in `fn_801ACFE8` scores 98.53658%. Other users treat it as
+  an integer handle, and the retained `u32` declaration reproduces the unsigned comparison.
+- A ternary clamp in `fn_8018E0D8` scores 93.7%. The explicit `if`/`else` form matches the
+  retail control flow and is clearer about the saturated value.
+- Alternative compiler optimization settings leave `fn_801B1BA0` at 99.3%. Its retained
+  source and existing per-file settings match exactly after both jump tables are externalized.

--- a/src/game/game_fn_8006B0F0.c
+++ b/src/game/game_fn_8006B0F0.c
@@ -3,28 +3,21 @@ typedef unsigned int u32;
 
 #pragma use_lmw_stmw on
 
-typedef struct Kinds {
-    s32 values[3];
-} Kinds;
-
-extern const Kinds lbl_80239090;
 extern void *fn_80036D38(s32 object);
 extern s32 fn_80066D04(s32 object, s32 kind);
 extern s32 fn_801A7770(s32 value);
 
 s32 fn_8006B0F0(s32 kind, s32 object, s32 unused, s32 value)
 {
-    Kinds kinds;
-    void *state = fn_80036D38(object);
+    s32 kinds[3] = {0, 2, 3};
     s32 i;
-
-    kinds = lbl_80239090;
+    void *state = fn_80036D38(object);
 
     for (i = 0; i < 3; i++) {
-        if (kind == kinds.values[i] && fn_80066D04(object, kinds.values[i]) &&
-            (*(u32 *)((char *)state + 0xB8) & (1U << kinds.values[i])) &&
-            kinds.values[i] == fn_801A7770(value)) {
-            return kinds.values[i];
+        if (kind == kinds[i] && fn_80066D04(object, kinds[i]) &&
+            (*(u32 *)((char *)state + 0xB8) & (1U << kinds[i])) &&
+            kinds[i] == fn_801A7770(value)) {
+            return kinds[i];
         }
     }
     return -1;

--- a/src/game/game_fn_8006E53C.c
+++ b/src/game/game_fn_8006E53C.c
@@ -7,10 +7,10 @@ typedef struct Owner {
 
 extern void *fn_80201B9C();
 extern void *fn_80204844(void *heap, int size);
-extern Owner *fn_8006D444(void);
+extern Owner *fn_8006D444(void *);
 extern int fn_8006BCE4(Owner *owner);
 extern void fn_8006D1DC(void);
-extern void *fn_80201814();
+extern void *fn_80201814(void *);
 extern void fn_8006E754(Owner *owner, int value);
 extern void fn_8006F544(Owner *owner, int value);
 extern void fn_80070C3C(void);
@@ -25,16 +25,27 @@ extern void fn_8011E174(int value, int zero);
 
 void fn_8006E53C(void)
 {
-    void *object;
     Owner *owner;
+    void *object;
     int kind;
 
     object = fn_80204844(fn_80201B9C(), 0x20);
-    if (object != 0 && (owner = fn_8006D444()) != 0) {
+    if (object != 0 && (owner = fn_8006D444(object)) != 0) {
         kind = fn_8006BCE4(owner);
         if (kind != -1) {
             fn_8006D1DC();
-            if (kind >= 9 && kind <= 0x23) {
+            switch (kind) {
+            case 9:
+            case 11:
+            case 16:
+            case 17:
+            case 18:
+            case 19:
+            case 29:
+            case 32:
+            case 33:
+            case 35:
+            case 36:
                 fn_80201814(owner->resource);
                 fn_8006E754(owner, 1);
                 fn_8006F544(owner, 1);
@@ -42,8 +53,10 @@ void fn_8006E53C(void)
                 if (!fn_801A5CE0() && !fn_801A5D04()) {
                     fn_801A5C30(1);
                 }
-            } else {
+                break;
+            default:
                 fn_80070F74(owner);
+                break;
             }
             fn_8006E644(kind, owner);
             fn_8006BD78(owner);

--- a/src/game/game_fn_8007D4D8.c
+++ b/src/game/game_fn_8007D4D8.c
@@ -5,9 +5,18 @@ typedef int s32;
 typedef struct Vec3 {
     float x, y, z;
 } Vec3;
+typedef union PackedVec3 {
+    Vec3 vector;
+    s32 first_word;
+} PackedVec3;
+typedef struct Hit8007D4D8 {
+    u8 pad00[8];
+    Vec3 position;
+    u8 pad14[0x14];
+} Hit8007D4D8;
 
-extern double lbl_8064E9D8;
-extern float lbl_8064E9FC;
+extern const double lbl_8064E9D8;
+extern const float lbl_8064E9FC;
 extern u8 lbl_802FC5BC[];
 
 extern s32 fn_801A7498(void *);
@@ -18,16 +27,14 @@ extern s32 fn_8011F6A4(void *, s32, s32, s32, void *, s32);
 extern void *fn_8006D444(void *);
 extern int fn_801AC9F4(s32, s32, Vec3 *, s32);
 extern unsigned int fn_800FBFB0(void);
-#define fn_800FBFB0() ((int)fn_800FBFB0())
-extern void fn_8014D478(s32, Vec3 *, Vec3 *, s32, s32, void *, s32);
+extern void fn_8014D478(void *, Vec3 *, Vec3 *, s32, s32, void *, s32);
 extern s32 fn_801A9EF4(s32, s32);
-extern void *fn_80201814();
-extern void *fn_80201BC8();
+extern void *fn_80201814(void *);
+extern Vec3 *fn_80201BC8(void *);
 extern float fn_8012B750(void *);
-extern void fn_8011F114();
+extern void fn_8011F114(Vec3 *, Vec3 *);
 extern unsigned long long fn_8020123C();
 
-/* NonMatching: honest reconstruction of the effect/event callback. */
 s32 fn_8007D4D8(void *unused, void *handle)
 {
     s32 owner_id;
@@ -36,10 +43,11 @@ s32 fn_8007D4D8(void *unused, void *handle)
     u8 *state;
     u8 *slot;
     s32 result;
-    Vec3 position;
+    Hit8007D4D8 hit;
     Vec3 velocity;
-    Vec3 direction;
-    void *target;
+    PackedVec3 direction;
+    s32 packed;
+    Vec3 *target;
 
     (void)unused;
     if (handle != 0) {
@@ -47,25 +55,25 @@ s32 fn_8007D4D8(void *unused, void *handle)
         object = fn_8004914C(handle);
         if (object != 0) {
             resource = fn_80204844(fn_80201B9C(object), 0x20);
-            result = fn_8011F6A4(object, 2, -1, -1, &direction, 1);
+            result = fn_8011F6A4(object, 2, -1, -1, &hit, 1);
             state = fn_8006D444(resource);
             slot = *(u8 **)(state + 0xC4);
             if (result != -1) {
-                fn_801AC9F4(0x176, 0x64, &position, 2);
-                velocity.x = (float)(8 - (fn_800FBFB0() & 0xF));
-                velocity.y = (float)(8 - (fn_800FBFB0() & 0xF));
+                fn_801AC9F4(0x176, 0x64, &hit.position, 2);
+                velocity.x = (float)(8 - (int)(fn_800FBFB0() & 0xF));
+                velocity.y = (float)(8 - (int)(fn_800FBFB0() & 0xF));
                 velocity.z = lbl_8064E9FC;
-                fn_8014D478(0, &position, &velocity, 0x10, 4,
+                fn_8014D478((void *)0, &hit.position, &velocity, 0x10, 4,
                             lbl_802FC5BC + 0x18, 3);
                 fn_801AC9F4((u16)fn_801A9EF4(0x115, 0x117), 0x6E,
-                            &position, 2);
+                            &hit.position, 2);
             }
-            fn_80201814(*(void **)(state + 0x38));
-            target = fn_80201BC8();
+            target = fn_80201BC8(fn_80201814(*(void **)(state + 0x38)));
             *(float *)(slot + 0x80) = fn_8012B750(target);
-            fn_8011F114(&direction, target);
-            *(Vec3 *)(slot + 0x74) = direction;
-            fn_8020123C(8, 0, owner_id, 0, *(s32 *)&direction);
+            fn_8011F114(&direction.vector, target);
+            packed = direction.first_word;
+            *(Vec3 *)(slot + 0x74) = direction.vector;
+            fn_8020123C(8, 0, owner_id, 0, packed);
         }
     }
     return 1;

--- a/src/game/game_fn_8007F770.c
+++ b/src/game/game_fn_8007F770.c
@@ -16,6 +16,6 @@ s32 fn_8007F770(void *script)
         return 0;
     }
 
-    fn_8016A830(script, (double)*(u32 *)(lbl_8031CD84 + 0x444 + lbl_8064C8F0 * 8));
+    fn_8016A830(script, (double)((u32 *)(lbl_8031CD84 + 0x444))[lbl_8064C8F0 * 2]);
     return 1;
 }

--- a/src/game/game_fn_80088F4C.c
+++ b/src/game/game_fn_80088F4C.c
@@ -15,8 +15,8 @@ typedef struct Vector {
 
 extern void *fn_80201B9C();
 extern void* fn_80204844(void*, int);
-extern State* fn_8006D444(void);
-extern void *fn_80201814();
+extern State* fn_8006D444(void*);
+extern void *fn_80201814(void*);
 extern int fn_80038308(void*, int, s16*);
 extern int fn_80038464(void*, int, s16*);
 extern int fn_800460EC(void);
@@ -28,22 +28,24 @@ extern void fn_801FA66C(int, int, float);
 extern void fn_801FA748(int, Vector*);
 extern unsigned int lbl_8064C920;
 extern int lbl_8064D18C;
-extern float lbl_8064EB7C;
+extern const float lbl_8064EB7C;
 extern const Vector lbl_8023953C;
 
 void fn_80088F4C(void)
 {
     State* state;
+    void* resource;
     void* object;
     int enabled;
     int valid;
     s16 maximum;
     s16 current;
 
-    if (fn_80204844(fn_80201B9C(), 0x20) == 0) {
+    resource = fn_80204844(fn_80201B9C(), 0x20);
+    if (resource == 0) {
         return;
     }
-    state = fn_8006D444();
+    state = fn_8006D444(resource);
     if (state == 0) {
         return;
     }

--- a/src/game/game_fn_80090004.c
+++ b/src/game/game_fn_80090004.c
@@ -1,3 +1,4 @@
+typedef unsigned char u8;
 typedef struct SceneEntry {
     int mode;
     void* value;
@@ -7,23 +8,28 @@ typedef struct SceneEntry {
     short amount;
 } SceneEntry;
 
+#define SCENE_VALUE_AT(value_column, scene, row, column)                   \
+    (*(void**)((value_column) + (scene) * sizeof(SceneEntry) * 8 +        \
+               (row) * sizeof(SceneEntry) * 4 +                          \
+               (column) * sizeof(SceneEntry)))
+
 extern SceneEntry lbl_8031D3F8[][2][4];
 extern int lbl_8064C560;
 extern int lbl_8064C564;
 extern int lbl_8064C578;
-extern float lbl_8064EC24;
+extern const float lbl_8064EC24;
 
 extern void* fn_8008F224(void*, int, int);
-extern void *fn_80201814();
-extern void *fn_80201B8C();
-extern int fn_80201B44();
+extern void *fn_80201814(void *);
+extern void *fn_80201B8C(void *);
+extern int fn_80201B44(void);
 extern void fn_801ACACC(int, int, void*, int);
 extern void fn_800DE4D8(void*, int);
-extern void *fn_80201BC8();
+extern void *fn_80201BC8(void *);
 extern unsigned int fn_8011FA8C(void*, int, int);
 extern int fn_80036D5C(void*);
 extern void fn_80036DA4(void*, int);
-extern int fn_80201EB8();
+extern int fn_80201EB8(void *);
 extern void fn_80201D34(void*, int);
 extern void fn_80201D1C(void*, int);
 extern void fn_8008F860(void*);
@@ -38,11 +44,14 @@ void fn_80090004(void* object, void* actor, void* target, void* unused4,
                  void* unused5, void* unused6, void* unused7, void* unused8,
                  void* resource)
 {
-    SceneEntry* entry = &lbl_8031D3F8[lbl_8064C578][lbl_8064C560][lbl_8064C564];
-    void* owner = fn_8008F224(entry->value, 1, 1);
-    void* state = fn_80201814(owner);
+    u8* value_column = (u8*)&lbl_8031D3F8[0][0][0].value;
+    void* state;
+    void* owner = fn_8008F224(
+        SCENE_VALUE_AT(value_column, lbl_8064C578, lbl_8064C560, lbl_8064C564),
+        1, 1);
     int next;
 
+    state = fn_80201814(owner);
     fn_80201B8C(state);
     fn_801ACACC(0xC1, 0x4B, ((void*)fn_80201B44()), 0x82);
     fn_800DE4D8(owner, 2);
@@ -68,6 +77,9 @@ void fn_80090004(void* object, void* actor, void* target, void* unused4,
         short amount = lbl_8031D3F8[lbl_8064C578][next][0].amount;
         fn_8008F860(target);
         fn_8020104C(23, target, target, -1, (float)amount);
-        fn_8011FB54(actor, lbl_8031D3F8[lbl_8064C578][lbl_8064C560][lbl_8064C564].value);
+        fn_8011FB54(actor, SCENE_VALUE_AT(value_column, lbl_8064C578,
+                                         lbl_8064C560, lbl_8064C564));
     }
 }
+
+#undef SCENE_VALUE_AT

--- a/src/game/game_fn_80095D10.c
+++ b/src/game/game_fn_80095D10.c
@@ -4,15 +4,16 @@ typedef struct Runtime80095D10 {
     int* values;
 } Runtime80095D10;
 
-extern void *fn_80201BC8();
-extern void *fn_80201B8C();
-extern void* fn_80201B3C();
+extern void *fn_80201BC8(void *);
+extern void *fn_80201B8C(void *);
+extern void* fn_80201B3C(void);
 extern int fn_80128EAC(void*);
 extern int fn_80038308(void*, int, short*);
 extern int fn_80038464(void*, int, short*);
 extern int fn_80201B64(void*);
 extern const float lbl_8064ECD4;
 
+#pragma global_optimizer off
 int fn_80095D10(register void* object)
 {
     register void* owner;
@@ -52,3 +53,4 @@ int fn_80095D10(register void* object)
     }
     return 4;
 }
+#pragma global_optimizer reset

--- a/src/game/game_fn_8009E808.c
+++ b/src/game/game_fn_8009E808.c
@@ -9,7 +9,7 @@ typedef struct Context8009E808 {
     u32 flags;
 } Context8009E808;
 
-extern void *fn_8006ED3C();
+extern Context8009E808 *fn_8006ED3C(void *, int, int *);
 extern void fn_801E7974(void*, int);
 extern void* fn_8006D488(void*);
 extern void fn_802020B4(void*, int);
@@ -17,15 +17,16 @@ extern void fn_801A5C30(int);
 extern void fn_80052424(int, int, int, int);
 extern void* lbl_8064C4E0;
 
-int fn_8009E808(void* state)
+#pragma opt_propagation off
+int fn_8009E808(void* event)
 {
-    int index;
     s16 sounds[4] = { 101, 102, 103, 104 };
+    int index;
     Context8009E808* context;
     register void* owner;
     int sound_index;
 
-    owner = state;
+    owner = event;
     context = fn_8006ED3C(owner, 0xC, &index);
     sound_index = context->counter % 4;
     fn_801E7974(lbl_8064C4E0, 0x3BF);
@@ -38,3 +39,4 @@ int fn_8009E808(void* state)
     }
     return 1;
 }
+#pragma opt_propagation reset

--- a/src/game/game_fn_800A3180.c
+++ b/src/game/game_fn_800A3180.c
@@ -6,30 +6,25 @@ typedef struct Vec3_800A3180 {
     float z;
 } Vec3_800A3180;
 
-extern void* fn_80201B94();
-extern int fn_80201C48(void);
-extern void *fn_80201814();
+extern void* fn_80201B94(void*);
+extern int fn_80201C48(void*);
+extern void *fn_80201814(int);
 extern u16 fn_800A30CC(void*);
 extern void fn_802045AC(void*, Vec3_800A3180*);
-extern void fn_80211A6C();
+extern void fn_80211A6C(Vec3_800A3180*, Vec3_800A3180*, Vec3_800A3180*);
 extern int fn_800A4F44(Vec3_800A3180*, float);
 
-/*
- * Behavior-complete, size-equal reconstruction. Retail assigns result/radius
- * to r31/r30, while this isolated TU assigns them to r30/r31. It also names
- * the unsigned-to-float bias relocation as lbl_8064EE78 instead of MWCC's
- * TU-local @11 constant. Objdiff: 66.041664%, 192/192 bytes.
- */
 int fn_800A3180(void* object, Vec3_800A3180* target)
 {
-    int condition;
-    u16 radius;
     int result;
+    int radius;
+    void* handle;
+    int linked;
 
-    fn_80201B94();
-    condition = fn_80201C48();
+    handle = fn_80201B94(object);
+    linked = fn_80201C48(handle);
     result = 0;
-    if (condition != 0 && fn_80201814() != 0) {
+    if (linked != 0 && fn_80201814(linked) != 0) {
         Vec3_800A3180 position;
         Vec3_800A3180 delta;
 

--- a/src/game/game_fn_800BB5C4.c
+++ b/src/game/game_fn_800BB5C4.c
@@ -17,24 +17,21 @@ typedef struct Owner {
 } Owner;
 
 extern void *memcpy(void *, const void *, unsigned int);
-extern int fn_80201B54();
-extern float fn_80200534(void *, int, int);
+extern int fn_80201B54(void *);
+extern float fn_80200534(int, int, int);
 extern int fn_80117E58(void);
 extern float fn_80200BDC(void);
-extern void *fn_80201B8C();
+extern Owner *fn_80201B8C(void *);
 
 unsigned short fn_800BB5C4(void *output, void *object)
 {
     Output result;
-    float tick;
     float time;
 
-    time = fn_80200534(((void *)fn_80201B54(object)), -1, 0x39);
-    tick = fn_80117E58();
-
-    time += fn_80200BDC() - tick;
+    time = fn_80200534(fn_80201B54(object), -1, 0x39);
+    time += fn_80200BDC() - fn_80117E58();
     if (time >= 0.0f) {
-        Source *source = ((Owner *)fn_80201B8C(object))->source;
+        Source *source = fn_80201B8C(object)->source;
         result.second = source->second;
         result.first = source->first;
     }

--- a/src/game/game_fn_800BB9A4.c
+++ b/src/game/game_fn_800BB9A4.c
@@ -1,16 +1,47 @@
-typedef struct Message { unsigned int first; unsigned int second; float time; unsigned char byte; unsigned char pad[3]; } Message;
-typedef struct Source { unsigned char pad[4]; unsigned int first; unsigned int second; unsigned char padC[6]; unsigned char byte; } Source;
-typedef struct Owner { unsigned char pad[0x30]; Source *source; } Owner;
+typedef struct Message {
+    unsigned int first;
+    unsigned int second;
+    float time;
+    unsigned char byte;
+    unsigned char pad[3];
+} Message;
+
+typedef struct Source {
+    unsigned char pad[4];
+    unsigned int first;
+    unsigned int second;
+    unsigned char padC[6];
+    unsigned char byte;
+} Source;
+
+typedef struct Owner {
+    unsigned char pad[0x30];
+    Source *source;
+} Owner;
+
 extern void *memcpy(void *, const void *, unsigned int);
-extern int fn_80201B54(); extern float fn_80200534(void *, int, int);
-extern int fn_80117E58(void); extern float fn_80200BDC(void); extern void *fn_80201B8C();
-extern float lbl_8064F010; extern double lbl_8064F020;
+extern int fn_80201B54(void *);
+extern float fn_80200534(int, int, int);
+extern int fn_80117E58(void);
+extern float fn_80200BDC(void);
+extern Owner *fn_80201B8C(void *);
+extern const float lbl_8064F010;
+extern const double lbl_8064F020;
+
 unsigned short fn_800BB9A4(void *output, void *object)
 {
-    Message result; float tick; float time;
-    time = fn_80200534(((void *)fn_80201B54(object)), -1, 0x39);
-    tick = fn_80117E58();
-    time += fn_80200BDC() - tick;
-    if (time > lbl_8064F010) { Source *source = ((Owner *)fn_80201B8C(object))->source; result.first = source->first; result.second = source->second; result.byte = source->byte; }
-    result.time = time; memcpy(output, &result, sizeof(result)); return sizeof(result);
+    Message result;
+    float time;
+
+    time = fn_80200534(fn_80201B54(object), -1, 0x39);
+    time += fn_80200BDC() - fn_80117E58();
+    if (time > lbl_8064F010) {
+        Source *source = fn_80201B8C(object)->source;
+        result.first = source->first;
+        result.second = source->second;
+        result.byte = source->byte;
+    }
+    result.time = time;
+    memcpy(output, &result, sizeof(result));
+    return sizeof(result);
 }

--- a/src/game/game_fn_800BBAF0.c
+++ b/src/game/game_fn_800BBAF0.c
@@ -1,16 +1,38 @@
-typedef struct Message { unsigned int value; float time; } Message;
-typedef struct Source { unsigned char pad[4]; unsigned int value; } Source;
-typedef struct Owner { unsigned char pad[0x34]; Source *source; } Owner;
+typedef struct Message {
+    unsigned int value;
+    float time;
+} Message;
+
+typedef struct Source {
+    unsigned char pad[4];
+    unsigned int value;
+} Source;
+
+typedef struct Owner {
+    unsigned char pad[0x34];
+    Source *source;
+} Owner;
+
 extern void *memcpy(void *, const void *, unsigned int);
-extern int fn_80201B54(); extern float fn_80200534(void *, int, int);
-extern int fn_80117E58(void); extern float fn_80200BDC(void); extern void *fn_80201B8C();
-extern float lbl_8064F010; extern double lbl_8064F020;
+extern int fn_80201B54(void *);
+extern float fn_80200534(int, int, int);
+extern int fn_80117E58(void);
+extern float fn_80200BDC(void);
+extern Owner *fn_80201B8C(void *);
+extern const float lbl_8064F010;
+extern const double lbl_8064F020;
+
 unsigned short fn_800BBAF0(void *output, void *object)
 {
-    Message result; float tick; float time;
-    time = fn_80200534(((void *)fn_80201B54(object)), -1, 0x39);
-    tick = fn_80117E58();
-    time += fn_80200BDC() - tick;
-    if (time >= lbl_8064F010) result.value = ((Owner *)fn_80201B8C(object))->source->value;
-    result.time = time; memcpy(output, &result, sizeof(result)); return sizeof(result);
+    Message result;
+    float time;
+
+    time = fn_80200534(fn_80201B54(object), -1, 0x39);
+    time += fn_80200BDC() - fn_80117E58();
+    if (time >= lbl_8064F010) {
+        result.value = fn_80201B8C(object)->source->value;
+    }
+    result.time = time;
+    memcpy(output, &result, sizeof(result));
+    return sizeof(result);
 }

--- a/src/game/game_fn_800CF598.c
+++ b/src/game/game_fn_800CF598.c
@@ -13,11 +13,11 @@ typedef struct RuntimeState {
 } RuntimeState;
 
 extern const Vec3f lbl_80239934;
-extern float lbl_8064F340;
+extern const float lbl_8064F340;
 extern int lbl_8064D18C;
-extern void *fn_80201B8C();
-extern void *fn_80201BC8();
-extern void fn_8011F114();
+extern void *fn_80201B8C(void *);
+extern Vec3f *fn_80201BC8(void *);
+extern void fn_8011F114(Vec3f *, Vec3f *);
 extern void fn_801AAE68(int, int, int, Vec3f *, int, int, int, u16, int,
                        float);
 
@@ -26,7 +26,7 @@ void fn_800CF598(void *object)
     RuntimeState *state;
     int effect;
     Vec3f position;
-    void *source;
+    Vec3f *source;
 
     if (object == 0) {
         return;
@@ -39,17 +39,31 @@ void fn_800CF598(void *object)
         fn_8011F114(&position, source);
     }
     switch (state->kind) {
-    case 4:
-        effect = 620;
+    case 3:
+    case 10:
+    case 11:
+    case 22:
+    case 24:
+    case 37:
+    case 38:
+    case 39:
+    case 41:
+        effect = 622;
         break;
     case 5:
         effect = 621;
         break;
     case 6:
+        effect = 620;
+        break;
+    case 4:
         effect = 624;
         break;
     case 7:
         effect = 625;
+        break;
+    case 8:
+        effect = 622;
         break;
     case 12:
         effect = 624;

--- a/src/game/game_fn_800D9E10.c
+++ b/src/game/game_fn_800D9E10.c
@@ -19,21 +19,22 @@ typedef struct Vec {
     float z;
 } Vec;
 
-extern void *fn_801A7498(void *);
-extern void *fn_80201814();
+extern u32 fn_801A7498(void *);
+extern void *fn_80201814(u32);
 extern Actor *fn_800A1D28(void *);
 extern ShortVec *fn_8017FDE4(void *);
 extern void fn_801A75C0(Vec *, void *, int, Vec *);
 extern void fn_801A7560(void *, int);
 
-int fn_800D9E10(void *unused, void *object)
+int fn_800D9E10(void *unused, u32 context)
 {
-    int i;
-    u32 target = (u32)object;
-    Actor *actor = fn_800A1D28(fn_80201814(fn_801A7498((void *)target)));
+    void *target = (void *)context;
+    Actor *actor = fn_800A1D28(fn_80201814(fn_801A7498(target)));
 
     (void)unused;
     {
+        int i;
+
         for (i = 0; i < 4; i++) {
             void *effect = actor->effects[i % 3];
             if (effect != 0) {
@@ -43,10 +44,10 @@ int fn_800D9E10(void *unused, void *object)
                 input.x = offset->x;
                 input.y = offset->y;
                 input.z = offset->z + 20;
-                fn_801A75C0(&output, (void *)target, i, &input);
+                fn_801A75C0(&output, target, i, &input);
             }
         }
     }
-    fn_801A7560((void *)target, 0x4000);
+    fn_801A7560(target, 0x4000);
     return 1;
 }

--- a/src/game/game_fn_8012976C.c
+++ b/src/game/game_fn_8012976C.c
@@ -1,24 +1,41 @@
 typedef unsigned char u8;
-#define FN_80128E30_RETURN u8*
-#define FN_80128E30_PARAMETERS void*
-extern FN_80128E30_RETURN fn_80128E30(FN_80128E30_PARAMETERS);
+
+typedef struct Vec3 {
+    float x;
+    float y;
+    float z;
+} Vec3;
+
+typedef struct Owner {
+    Vec3 position;
+    u8 pad0C[0x34];
+    u8* effects;
+} Owner;
+
+extern u8* fn_80128E30(void*);
 extern int fn_80129C2C(void*, u8*, int, int, int);
 extern void fn_80129CE8(void*, u8*, int, int, int);
-extern void fn_801299DC(u8*, int*);
+extern void fn_801299DC(u8*, Vec3*);
 extern void fn_80129BA4(u8*, float, float);
 extern void fn_80129DE0(void*, u8*, int, int);
 
-u8* fn_8012976C(int* position, int kind, int flags, int value, float scale)
+u8* fn_8012976C(Owner* owner, int kind, int flags, Vec3* position, float scale)
 {
-    u8* entry = fn_80128E30(position);
-    if (fn_80129C2C(position, entry, kind, flags, 5)) {
+    u8* entry = fn_80128E30(owner);
+    if (fn_80129C2C(owner, entry, kind, flags, 5)) {
         u8* resource = *(u8**)(entry + 0xB8);
-        if (resource) *(*(u8**)((u8*)position + 0x40) + 0x884) = resource[0xD];
-        fn_80129CE8(position, entry, kind, flags, 5);
-        fn_801299DC(entry, &value);
-        *(int*)(entry + 0xD8) = position[0]; *(int*)(entry + 0xDC) = position[1]; *(int*)(entry + 0xE0) = position[2];
-        if ((*(int*)(entry + 0xF4) & 0x40) == 0) fn_80129BA4(entry, 1.0f, scale);
-        fn_80129DE0(position, entry, (flags & 0x10000) == 0, 1);
-    } else entry = 0;
+        if (resource != 0) {
+            owner->effects[0x884] = resource[0xD];
+        }
+        fn_80129CE8(owner, entry, kind, flags, 5);
+        fn_801299DC(entry, position);
+        *(Vec3*)(entry + 0xD8) = owner->position;
+        if ((*(int*)(entry + 0xF4) & 0x40) == 0) {
+            fn_80129BA4(entry, 0.0f, scale);
+        }
+        fn_80129DE0(owner, entry, !(flags & 0x10000), 1);
+    } else {
+        entry = 0;
+    }
     return entry;
 }

--- a/src/game/game_fn_8014CA98.c
+++ b/src/game/game_fn_8014CA98.c
@@ -1,31 +1,30 @@
-extern float lbl_8023A728[3];
-extern double lbl_806504F0;
-extern void *fn_80156938();
-extern void *fn_80201BC8();
-extern short fn_801FE9DC(void*);
-extern void fn_8012B690(void*, float*, float*);
-extern void fn_801FDEB4(void*, float*);
+typedef struct Vec3 {
+    float x;
+    float y;
+    float z;
+} Vec3;
 
-/*
- * Honest NonMatching reconstruction. The transform setup and signed-angle
- * conversion are behavior-complete; retail retains a distinct runtime/owner
- * allocation and one additional conversion-scheduling instruction.
- */
+extern const Vec3 lbl_8023A728;
+extern const double lbl_806504F0;
+extern void *fn_80156938(void *);
+extern void *fn_80201BC8(void *);
+extern short fn_801FE9DC(void*);
+extern void fn_8012B690(void*, const Vec3*, Vec3*);
+extern void fn_801FDEB4(void*, Vec3*);
+
 void fn_8014CA98(void* first, void* second)
 {
-    float result[3];
-    float value[3];
-    void* owner;
+    Vec3 value;
+    Vec3 result;
     void* runtime;
+    void* owner;
 
     owner = fn_80201BC8(fn_80156938(second));
     runtime = fn_80156938(first);
     if (runtime != 0) {
-        value[0] = lbl_8023A728[0];
-        value[1] = lbl_8023A728[1];
-        value[2] = lbl_8023A728[2];
-        value[1] = (float)-fn_801FE9DC(runtime);
-        fn_8012B690(owner, value, result);
-        fn_801FDEB4(runtime, result);
+        value = lbl_8023A728;
+        value.y = (float)-fn_801FE9DC(runtime);
+        fn_8012B690(owner, &value, &result);
+        fn_801FDEB4(runtime, &result);
     }
 }

--- a/src/game/game_fn_80153A24.c
+++ b/src/game/game_fn_80153A24.c
@@ -16,6 +16,10 @@ extern float fn_80048C2C(float);
 extern float fn_80048C50(float);
 extern int fn_801E8328();
 
+extern const float lbl_806505B8;
+extern const float lbl_806505BC;
+extern const float lbl_806505C0;
+
 void fn_80153A24(Vec3* origin, int count, u16 radius, u16 first_kind,
                  u16 second_kind, EffectDescriptor* first,
                  EffectDescriptor* second, u8 variant)
@@ -25,20 +29,21 @@ void fn_80153A24(Vec3* origin, int count, u16 radius, u16 first_kind,
     Vec3 position;
     int i;
     float angle;
+    EffectDescriptor* targets[2];
 
     fn_80182380(&first_template);
     first_template.data[0] = 4;
     first_template.data[1] = 2;
-    first_template.data[2] = 100;
-    *(signed char*)(first_template.data + 3) = -10;
     *(u16*)(first_template.data + 4) = first_kind;
     *(u16*)(first_template.data + 6) = 60;
     *(u16*)(first_template.data + 8) = 8;
-    *(u16*)(first_template.data + 0x18) = 0;
+    first_template.data[2] = 100;
+    *(signed char*)(first_template.data + 3) = -10;
     *(u16*)(first_template.data + 0x1A) = 2;
+    *(u16*)(first_template.data + 0x18) = 0;
     first_template.data[0x1F] = 1;
     first_template.data[0x20] = 1;
-    *(float*)(first_template.data + 0x28) = 1.0f;
+    *(float*)(first_template.data + 0x28) = lbl_806505B8;
     first_template.data[0x21] = 50;
     first_template.data[0x22] = 100;
     first_template.data[0x23] = 96;
@@ -52,16 +57,16 @@ void fn_80153A24(Vec3* origin, int count, u16 radius, u16 first_kind,
     fn_80182380(&second_template);
     second_template.data[0] = 6;
     second_template.data[1] = 8;
-    second_template.data[2] = 250;
-    *(signed char*)(second_template.data + 3) = -25;
     *(u16*)(second_template.data + 4) = second_kind;
     *(u16*)(second_template.data + 6) = 50;
     *(u16*)(second_template.data + 8) = 7;
-    *(u16*)(second_template.data + 0x18) = 0;
+    second_template.data[2] = 250;
+    *(signed char*)(second_template.data + 3) = -25;
     *(u16*)(second_template.data + 0x1A) = 3;
+    *(u16*)(second_template.data + 0x18) = 0;
     second_template.data[0x1F] = 1;
     second_template.data[0x20] = 1;
-    *(float*)(second_template.data + 0x28) = 1.0f;
+    *(float*)(second_template.data + 0x28) = lbl_806505BC;
     second_template.data[0x21] = 50;
     second_template.data[0x22] = 250;
     *(void (**)(void))(second_template.data + 0x90) = fn_80182448;
@@ -70,18 +75,20 @@ void fn_80153A24(Vec3* origin, int count, u16 radius, u16 first_kind,
     *(u16*)(second_template.data + 0xA8) = 1;
     second_template.data[0xAA] = variant;
 
+    targets[0] = first;
+    targets[1] = second;
     for (i = 0; i < count; i++) {
-        angle = 6.2831855f * (float)i / (float)count;
+        angle = lbl_806505C0 * (float)i / (float)count;
         position.x = origin->x + (float)radius * fn_80048C2C(angle);
-        position.z = origin->z;
         position.y = origin->y + (float)radius * fn_80048C50(angle);
-        *first = first_template;
-        *(Vec3*)(first->data + 0x98) = position;
-        fn_801E8328(16, first);
-        *second = second_template;
-        *(Vec3*)(second->data + 0x98) = position;
-        fn_801E8328(16, second);
-        first++;
-        second++;
+        position.z = origin->z;
+        *targets[0] = first_template;
+        *(Vec3*)(targets[0]->data + 0x98) = position;
+        fn_801E8328(16, targets[0]);
+        *targets[1] = second_template;
+        *(Vec3*)(targets[1]->data + 0x98) = position;
+        fn_801E8328(16, targets[1]);
+        targets[0]++;
+        targets[1]++;
     }
 }

--- a/src/game/game_fn_80174F2C.c
+++ b/src/game/game_fn_80174F2C.c
@@ -44,18 +44,16 @@ extern const char lbl_8024FF00[];
 extern const float lbl_806506B8;
 extern const float lbl_80650700;
 
-static inline void set_value00(CommandDescriptor* descriptor, double value)
-{
-    descriptor->value00 = (u16)value;
-}
-
+#pragma opt_common_subs off
+#pragma opt_propagation off
 int fn_80174F2C(void* state)
 {
     ResourceRef resource;
     Vec3s* source;
     int resource_id;
-    register CommandDescriptor* descriptor;
+    CommandDescriptor* descriptor;
     CommandDescriptor command;
+    u16 value00;
 
     if (fn_8016A598(state) != 10) {
         fn_80163BB4(state, lbl_8024FF00, 10, fn_8016A598(state));
@@ -70,7 +68,9 @@ int fn_80174F2C(void* state)
     command.bytes24[3] = fn_8016A694(state, 5);
     resource_id = fn_8016A694(state, 6);
     command.value28 = fn_8016A694(state, 7);
-    set_value00(descriptor = &command, fn_8016A694(state, 8));
+    value00 = fn_8016A694(state, 8);
+    descriptor = &command;
+    descriptor->value00 = value00;
     descriptor->value08 = fn_8016A694(state, 9);
     descriptor->value0C = fn_8016A694(state, 10);
     command.byte34 = 2;
@@ -84,3 +84,5 @@ int fn_80174F2C(void* state)
     fn_8014C37C(0, &resource);
     return 0;
 }
+#pragma opt_propagation reset
+#pragma opt_common_subs reset

--- a/src/game/game_fn_8017A12C.c
+++ b/src/game/game_fn_8017A12C.c
@@ -1,5 +1,6 @@
 extern float fn_80179F20(float angle);
 
+#pragma opt_propagation off
 void fn_8017A12C(float* out, float current, float target)
 {
     float wrapped;
@@ -20,3 +21,4 @@ void fn_8017A12C(float* out, float current, float target)
     difference_magnitude = difference < 0.0f ? -difference : difference;
     *out = difference_magnitude < wrapped_magnitude ? difference : wrapped;
 }
+#pragma opt_propagation reset

--- a/src/game/game_fn_8017AC20.c
+++ b/src/game/game_fn_8017AC20.c
@@ -5,10 +5,10 @@ extern void fn_800F8BAC(const char*, const char*, int);
 
 int fn_8017AC20(int scale, unsigned int bits, float value)
 {
-    int result = (int)(value * (1 << scale));
     const char* messages = lbl_80250D00;
-    /* Deliberately relies on MWCC's negative-left-shift behavior for retail codegen. */
-    unsigned int mask = bits == 32 ? -1 : -1 << bits;
+    float scaled = (float)(1 << scale);
+    unsigned int mask = bits == 32 ? ~0U : ~0U << bits;
+    int result = (int)(value * scaled);
 
     if (result != 0) {
         if (value < lbl_80650860) {

--- a/src/game/game_fn_8018680C.c
+++ b/src/game/game_fn_8018680C.c
@@ -2,34 +2,43 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef signed short s16;
 
-typedef struct Vec3s { s16 x, y, z; } Vec3s;
+typedef struct Vec3s {
+    s16 x;
+    s16 y;
+    s16 z;
+} Vec3s;
+
 extern s16 lbl_80606360[];
-extern double lbl_80650A10;
+extern const double lbl_80650A10;
 extern void* memcpy(void*, const void*, unsigned long);
 
 void fn_8018680C(u8* state, u8* entry, Vec3s* dst, int index, Vec3s* origin, u8 count)
 {
     int phase;
-    int offset;
+    s16 offset;
     u16 center;
+    s16* sine = lbl_80606360;
+    s16* cosine = lbl_80606360 + 64;
     u16 distance;
     Vec3s temp;
-    if (index < count - 1)
+    if (index < count - 1) {
         phase = (int)(index * *(float*)(state + 0x30)) & 0x3F;
-    else
+    } else {
         phase = 0;
+    }
     offset = entry[0x21];
-    if (state[5] & 2)
+    if (state[5] & 2) {
         offset = (s16)-offset;
+    }
     center = *(u16*)(state + 0xE);
     distance = center - offset;
-    temp.x = origin->x + ((distance * lbl_80606360[phase]) >> 7);
-    temp.y = origin->y + ((distance * lbl_80606360[64 + phase]) >> 7);
+    temp.x = origin->x + ((distance * sine[phase]) >> 7);
+    temp.y = origin->y + ((distance * cosine[phase]) >> 7);
     temp.z = origin->z;
     memcpy(dst, &temp, 6);
     distance = center + offset;
-    temp.x = origin->x + ((distance * lbl_80606360[phase]) >> 7);
-    temp.y = origin->y + ((distance * lbl_80606360[64 + phase]) >> 7);
+    temp.x = origin->x + ((distance * sine[phase]) >> 7);
+    temp.y = origin->y + ((distance * cosine[phase]) >> 7);
     temp.z = origin->z;
     memcpy((u8*)dst + 6, &temp, 6);
 }

--- a/src/game/game_fn_80186F70.c
+++ b/src/game/game_fn_80186F70.c
@@ -4,31 +4,29 @@ typedef signed short s16;
 
 extern int fn_800FBFB0(void);
 
-void fn_80186F70(s16* output, int count, int magnitude, float step, float base)
+void fn_80186F70(s16* output, int count, float step, float base, int range)
 {
     s16* destination;
     int step_integer = (int)step;
-    int range = magnitude;
     int sign = step_integer >> 31;
+    int index;
 
     if (((sign ^ step_integer) - sign) > range) {
-        int index;
+        int random_index;
 
         destination = output;
-        index = 0;
-        while (index < count) {
+        random_index = 0;
+        while (random_index < count) {
             int value = fn_800FBFB0() % step_integer;
             if (step_integer < 0) {
                 value = -value;
             }
             *destination = (s16)(base + (float)value);
             base += step;
-            index++;
+            random_index++;
             destination++;
         }
     } else {
-        int index;
-
         destination = output;
         index = 0;
         while (index < count) {

--- a/src/game/game_fn_80187BB4.c
+++ b/src/game/game_fn_80187BB4.c
@@ -1,4 +1,3 @@
-typedef signed char s8;
 typedef signed short s16;
 typedef unsigned char u8;
 typedef unsigned short u16;
@@ -23,11 +22,11 @@ void fn_80187BB4(u8* self, u8* desc)
 
     if (*(int*)(desc + 0x20) != 0) {
         *(float*)(self + 0xAC) =
-            (s8)(desc[0x34] - desc[0x30]) / (float)*(u16*)(desc + 0x2A);
+            (desc[0x34] - desc[0x30]) / (float)*(u16*)(desc + 0x2A);
         *(float*)(self + 0xB0) =
-            (s8)(desc[0x35] - desc[0x31]) / (float)*(u16*)(desc + 0x2A);
+            (desc[0x35] - desc[0x31]) / (float)*(u16*)(desc + 0x2A);
         *(float*)(self + 0xB4) =
-            (s8)(desc[0x36] - desc[0x32]) / (float)*(u16*)(desc + 0x2A);
+            (desc[0x36] - desc[0x32]) / (float)*(u16*)(desc + 0x2A);
         *(float*)(self + 0xB8) = desc[0x30];
         *(float*)(self + 0xBC) = desc[0x31];
         *(float*)(self + 0xC0) = desc[0x32];

--- a/src/game/game_fn_8018D400.c
+++ b/src/game/game_fn_8018D400.c
@@ -19,25 +19,25 @@ void fn_8018D400(u8* self, void* context, Callback callback)
 {
     Vec3 input;
     Vec3 output;
-    int half_width;
-    int half_height;
     int x_radius;
     int y_radius;
     unsigned int location;
-    u8* self_local;
+    u8* state;
     u8* coordinates;
-    void* context_local;
-    Callback callback_local;
+    int half_height;
+    int half_width;
+    void* callback_context;
+    Callback draw;
 
-    self_local = self;
-    coordinates = self_local + 0x10;
-    context_local = context;
-    callback_local = callback;
+    state = self;
+    coordinates = state + 0x10;
+    callback_context = context;
+    draw = callback;
     fn_80179B08(coordinates, &input);
     fn_8017ACE0(lbl_8063C068, &input, &output);
 
-    half_width = *(u16*)(self_local + 0xDC) >> 1;
-    half_height = *(u16*)(self_local + 0xDE) >> 1;
+    half_width = *(u16*)(state + 0xDC) >> 1;
+    half_height = *(u16*)(state + 0xDE) >> 1;
     location = fn_801F6D90(*(s16*)(coordinates + 0),
                            *(s16*)(coordinates + 2),
                            *(s16*)(coordinates + 4));
@@ -74,8 +74,7 @@ void fn_8018D400(u8* self, void* context, Callback callback)
         y_radius = 0;
     }
 
-    callback_local(context_local, output.x - (float)x_radius,
-                   output.y + (float)y_radius,
-                   output.x + (float)x_radius,
-                   output.y - (float)y_radius, output.z);
+    draw(callback_context, output.x - (float)x_radius,
+         output.y + (float)y_radius, output.x + (float)x_radius,
+         output.y - (float)y_radius, output.z);
 }

--- a/src/game/game_fn_8018E0D8.c
+++ b/src/game/game_fn_8018E0D8.c
@@ -1,22 +1,39 @@
 typedef unsigned char u8;
 typedef signed short s16;
+
+typedef struct Vec3 {
+    float x;
+    float y;
+    float z;
+} Vec3;
+
 extern u8 lbl_8063C068[];
-extern void fn_80179B08(void*, float*);
-extern void fn_8017ACE0(void*, float*, float*);
+extern void fn_80179B08(void*, Vec3*);
+extern void fn_8017ACE0(void*, Vec3*, Vec3*);
 extern int fn_801F6D90(s16, s16, s16);
 extern int fn_8018D1F0(u8, int);
+
 typedef void (*Callback)(void*, float, float, float, float, float);
+
 void fn_8018E0D8(u8* object, void* context, Callback callback)
 {
-    float position[3];
-    float projected[3];
-    int id;
+    Vec3 position;
+    Vec3 projected;
+    unsigned int id;
     int radius;
-    fn_80179B08(object + 0xA, position);
-    fn_8017ACE0(lbl_8063C068, position, projected);
-    id = fn_801F6D90(*(s16*)(object + 0xA), *(s16*)(object + 0xC), *(s16*)(object + 0xE));
+    float extent;
+
+    fn_80179B08(object + 0xA, &position);
+    fn_8017ACE0(lbl_8063C068, &position, &projected);
+    id = fn_801F6D90(*(s16*)(object + 0xA), *(s16*)(object + 0xC),
+                     *(s16*)(object + 0xE));
     radius = fn_8018D1F0(object[0x21], id);
-    callback(context, projected[0] - radius, projected[1] - radius,
-             projected[0] + radius, projected[1] + radius, projected[2]);
-    object[0x2B] = id >= 255 ? 255 : id;
+    extent = radius;
+    callback(context, projected.x - extent, projected.y - extent,
+             projected.x + extent, projected.y + extent, projected.z);
+    if (id >= 255) {
+        object[0x2B] = 255;
+    } else {
+        object[0x2B] = id;
+    }
 }

--- a/src/game/game_fn_8019120C.c
+++ b/src/game/game_fn_8019120C.c
@@ -24,17 +24,18 @@ extern void fn_80191F04(void*, u8, int);
 
 void fn_8019120C(State* object, int index)
 {
-    Entry* entry = (Entry*)(*(u8**)((u8*)object + 0x4C) + index * 0x38);
+    State* state = object;
+    Entry* entry = (Entry*)(*(u8**)((u8*)state + 0x4C) + index * 0x38);
 
     entry->alpha = (entry->alpha / -4) * -4;
     fn_8018E230(entry, &entry->alpha, 1, entry->alpha, -4, 0);
 
-    object = (State*)((u8*)object + 0x8C);
-    entry->velocity[0] = (s16)((float)entry->position[0] - object->position[0]);
-    entry->velocity[1] = (s16)((float)entry->position[1] - object->position[1]);
-    entry->velocity[2] = (int)((float)entry->position[2] - object->position[2]) >> 1;
+    state = (State*)((u8*)state + 0x8C);
+    entry->velocity[0] = (s16)((float)entry->position[0] - state->position[0]);
+    entry->velocity[1] = (s16)((float)entry->position[1] - state->position[1]);
+    entry->velocity[2] = (int)((float)entry->position[2] - state->position[2]) >> 1;
 
     fn_80179904(entry->velocity, (s16)((fn_800FBFB0() & 7) + 16));
     fn_8018F014(entry->velocity, 2);
-    fn_80191F04(object, (u8)index, 17);
+    fn_80191F04(state, (u8)index, 17);
 }

--- a/src/game/game_fn_801916D0.c
+++ b/src/game/game_fn_801916D0.c
@@ -4,22 +4,32 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-typedef struct ShortCoord3 {
+typedef struct ShortCoordComponents {
     s16 x;
     s16 y;
     s16 z;
+} ShortCoordComponents;
+
+typedef struct PackedShortCoord {
+    u32 word;
+    u16 half;
+} PackedShortCoord;
+
+typedef union ShortCoord3 {
+    ShortCoordComponents components;
+    PackedShortCoord packed;
 } ShortCoord3;
 
 extern u32 lbl_80651DA0;
 extern u16 lbl_80651DA4;
 extern u32 lbl_80650B28;
-extern float lbl_80650B20;
-extern float lbl_80650B2C;
+extern const float lbl_80650B20;
+extern const float lbl_80650B2C;
 extern void* lbl_8064D224;
-extern float lbl_80650B30;
-extern double lbl_80650B38;
-extern double lbl_80650B18;
-extern float lbl_80650B34;
+extern const float lbl_80650B30;
+extern const double lbl_80650B38;
+extern const double lbl_80650B18;
+extern const float lbl_80650B34;
 extern u8 lbl_802FC5BC[];
 extern u8 lbl_80607120[];
 extern u8 lbl_80606318[];
@@ -41,15 +51,17 @@ void fn_801916D0(u8* object, ShortCoord3* first, ShortCoord3* second,
                  u8* config)
 {
     ShortCoord3 zero;
-    u32 effect = lbl_80650B28;
-    u8* entry;
-    u8 count;
+    u32 effect;
     u32 i;
+    u8 count;
+    u8* entry;
     ShortCoord3 position;
     void* source;
+    float scale;
 
-    *(u32*)&zero = lbl_80651DA0;
-    *(u16*)((u8*)&zero + 4) = lbl_80651DA4;
+    zero.packed.word = lbl_80651DA0;
+    zero.packed.half = lbl_80651DA4;
+    effect = lbl_80650B28;
     entry = *(u8**)(object + 0x4C);
     count = config[0];
     fn_801804AC(object, first, second, &zero);
@@ -60,8 +72,8 @@ void fn_801916D0(u8* object, ShortCoord3* first, ShortCoord3* second,
     object[4] = config[3];
     *(s16*)(object + 0xE) = *(s16*)(config + 4);
     *(u16*)(object + 0xC) = *(u16*)(config + 6);
-    *(u16*)(object + 0xA) = 0;
     *(void**)(object + 0x68) = lbl_8064D224;
+    *(u16*)(object + 0xA) = 0;
     *(u32*)(object + 0x38) = *(u32*)(config + 0x30);
     *(u32*)(object + 0x44) = 0;
     *(float*)(object + 0x3C) = lbl_80650B20;
@@ -70,16 +82,19 @@ void fn_801916D0(u8* object, ShortCoord3* first, ShortCoord3* second,
         *(u32*)(object + 0x5C) = effect;
     }
     memset(object + 0x24, 0, 0x10);
+    scale = lbl_80650B30;
 
     for (i = 0; (u8)i < count; i++) {
-        float angle = lbl_80650B30 * (float)(u8)i / (float)count;
-        position.x = (s16)((float)*(s16*)(config + 0x28) *
-                           fn_80048C2C(angle) + *(float*)(config + 0x34));
-        position.y = (s16)((float)*(s16*)(config + 0x28) *
-                           fn_80048C50(angle) + *(float*)(config + 0x38));
-        position.z = (s16)*(float*)(config + 0x3C);
+        float angle = scale * (float)(u8)i / (float)count;
+        position.components.x =
+            (s16)((float)*(s16*)(config + 0x28) * fn_80048C2C(angle) +
+                  *(float*)(config + 0x34));
+        position.components.y =
+            (s16)((float)*(s16*)(config + 0x28) * fn_80048C50(angle) +
+                  *(float*)(config + 0x38));
+        position.components.z = (s16)*(float*)(config + 0x3C);
         fn_80180554(entry, &position, second, &zero, 0,
-                    (signed char)config[0x1B]);
+                    *(signed char*)(config + 0x1B));
         if (config[0x1A] == 0) {
             fn_80180518(object + 0x24, i, 1);
             source = lbl_802FC5BC + 0xC;

--- a/src/game/game_fn_801926EC.c
+++ b/src/game/game_fn_801926EC.c
@@ -1,51 +1,75 @@
-typedef signed char s8;
 typedef signed short s16;
 typedef signed int s32;
 typedef unsigned char u8;
 typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef union Colour {
+    u8 channels[4];
+    u32 packed;
+} Colour;
+
+typedef struct Vec3 {
+    float x;
+    float y;
+    float z;
+} Vec3;
 
 extern s32 lbl_8064D18C;
 extern void fn_801929A4(void);
 extern void* fn_80201814(void*);
 extern s32 fn_800FBFB0(void);
-extern void fn_8014D478(s32, float*, float*, s32, s32, u8*, s32);
+extern void fn_8014D478(void*, Vec3*, Vec3*, s32, s32, void*, s32);
 
 s32 fn_801926EC(u8* object)
 {
-    u8 colour[4];
-    float position[3];
-    float offset[3];
+    Colour colour;
+    Vec3 position;
+    Vec3 offset;
     u8* entry;
-    s32 count;
     s32 i;
+    s32 count;
+    s32 j;
+    u16 value;
 
     if (*(s32*)(object + 0x38) != lbl_8064D18C ||
         fn_80201814(*(void**)(object + 0xC8)) == 0 ||
-        **(s32***)(object + 0xD8) != 0) {
+        **(s32**)(object + 0xD8) != 0) {
         *(u16*)(object + 0x22) = 8;
     } else if (*(s32*)(object + 0xB8) != 0) {
-        *(void (**)(void))(object + 0x14C) = fn_801929A4;
         entry = *(u8**)(object + 0x4C);
+        *(void (**)(void))(object + 0x14C) = fn_801929A4;
         count = object[1] >> 1;
-        for (i = 0; i < count; i++, entry += 0x38)
+        for (i = 0; i < count; i++) {
             *(u16*)(entry + 8) = *(u16*)(object + 0xA);
-        for (; i < object[1]; i++, entry += 0x38)
-            *(u16*)(entry + 8) = (u16)(count + *(u16*)(object + 0xA));
+            entry += 0x38;
+        }
+        value = (u16)(count + *(u16*)(object + 0xA));
+        for (j = count; j < object[1]; j++) {
+            *(u16*)(entry + 8) = value;
+            entry += 0x38;
+        }
 
         if (*(s32*)(object + 0xBC) != 0) {
-            *(s32*)colour = *(s32*)(object + 0xDC);
-            position[0] = *(s16*)(object + 0x10);
-            position[1] = *(s16*)(object + 0x12);
-            position[2] = *(s16*)(object + 0x14);
-            offset[0] = *(s16*)(object + 0xC0) - *(s16*)(object + 0x10);
-            offset[1] = *(s16*)(object + 0xC2) - *(s16*)(object + 0x12);
-            offset[2] = *(s16*)(object + 0xC4) - *(s16*)(object + 0x14) + 100;
+            colour.packed = *(u32*)(object + 0xDC);
+            position.x = *(s16*)(object + 0x10);
+            position.y = *(s16*)(object + 0x12);
+            position.z = *(s16*)(object + 0x14);
+            offset.x = *(s16*)(object + 0xC0) - *(s16*)(object + 0x10);
+            offset.y = *(s16*)(object + 0xC2) - *(s16*)(object + 0x12);
+            offset.z = *(s16*)(object + 0xC4) - *(s16*)(object + 0x14) + 100;
             switch (object[0xB6]) {
-            case 1: colour[0] -= fn_800FBFB0() & 0x1F; break;
-            case 2: colour[1] -= fn_800FBFB0() & 0x1F; break;
-            case 3: colour[2] -= fn_800FBFB0() & 0x1F; break;
+            case 1:
+                colour.channels[0] -= fn_800FBFB0() & 0x1F;
+                break;
+            case 2:
+                colour.channels[1] -= fn_800FBFB0() & 0x1F;
+                break;
+            case 3:
+                colour.channels[2] -= fn_800FBFB0() & 0x1F;
+                break;
             }
-            fn_8014D478(0, position, offset, 0, 1, colour, 5);
+            fn_8014D478((void*)0, &position, &offset, 0, 1, colour.channels, 5);
         }
     }
     (*(u16*)(object + 0xA))++;

--- a/src/game/game_fn_80192F54.c
+++ b/src/game/game_fn_80192F54.c
@@ -2,6 +2,13 @@ typedef signed short s16;
 typedef signed int s32;
 typedef unsigned char u8;
 typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef struct Vec3 {
+    float x;
+    float y;
+    float z;
+} Vec3;
 
 extern s32 lbl_8064D18C;
 extern double lbl_80650B18;
@@ -10,14 +17,8 @@ extern float lbl_80650B4C;
 extern void fn_801931C4(void);
 extern void* fn_80201814(void*);
 extern s32 fn_800FBFB0(void);
-extern void fn_8014D478(s32, float*, float*, s32, s32, u8*, s32);
+extern void fn_8014D478(void*, Vec3*, Vec3*, s32, s32, void*, s32);
 extern void fn_8018EA58(void*);
-
-typedef struct Vec3 {
-    float x;
-    float y;
-    float z;
-} Vec3;
 
 typedef struct Colour {
     u8 red;
@@ -26,12 +27,18 @@ typedef struct Colour {
     u8 alpha;
 } Colour;
 
+typedef union PackedColour {
+    Colour channels;
+    u32 packed;
+} PackedColour;
+
+#pragma opt_common_subs off
 s32 fn_80192F54(u8* object)
 {
     float zero;
     Vec3 position;
     Vec3 offset;
-    Colour colour;
+    PackedColour colour;
     u8* entry;
     s32 i;
     s32 count;
@@ -61,7 +68,7 @@ s32 fn_80192F54(u8* object)
         }
 
         if (*(s32*)(object + 0xBC) != 0) {
-            *(s32*)&colour = *(s32*)(object + 0xDC);
+            colour.packed = *(u32*)(object + 0xDC);
             zero = lbl_80650B20;
             position.x = *(s16*)(object + 0x10);
             position.y = *(s16*)(object + 0x12);
@@ -70,14 +77,21 @@ s32 fn_80192F54(u8* object)
             offset.y = zero;
             offset.z = lbl_80650B4C;
             switch (object[0xB6]) {
-            case 1: colour.red -= fn_800FBFB0() & 0x1F; break;
-            case 2: colour.green -= fn_800FBFB0() & 0x1F; break;
-            case 3: colour.blue -= fn_800FBFB0() & 0x1F; break;
+            case 1:
+                colour.channels.red -= fn_800FBFB0() & 0x1F;
+                break;
+            case 2:
+                colour.channels.green -= fn_800FBFB0() & 0x1F;
+                break;
+            case 3:
+                colour.channels.blue -= fn_800FBFB0() & 0x1F;
+                break;
             }
-            fn_8014D478(0, (float*)&position, (float*)&offset, 0, 1, (u8*)&colour, 5);
+            fn_8014D478((void*)0, &position, &offset, 0, 1, &colour.channels, 5);
         }
     }
     (*(u16*)(object + 0xA))++;
     fn_8018EA58(object);
     return 0;
 }
+#pragma opt_common_subs reset

--- a/src/game/game_fn_801A2A54.c
+++ b/src/game/game_fn_801A2A54.c
@@ -2,8 +2,8 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-extern float lbl_80650D1C;
-extern double lbl_80650D20;
+extern const float lbl_80650D1C;
+extern const double lbl_80650D20;
 
 void fn_801A2A54(u8* object, int value)
 {

--- a/src/game/game_fn_801A34BC.c
+++ b/src/game/game_fn_801A34BC.c
@@ -1,6 +1,6 @@
 typedef unsigned char u8;
 typedef unsigned short u16;
-typedef unsigned long u32;
+typedef unsigned int u32;
 
 typedef struct ShortCoord3 {
     u32 word;
@@ -19,7 +19,7 @@ extern const double lbl_80650D20;
 void fn_801A34BC(u8* object, u8* descriptor)
 {
     u8* cursor;
-    u8 count;
+    int count;
     int i;
     u8* entry;
     ShortCoord3 second;

--- a/src/game/game_fn_801A657C.c
+++ b/src/game/game_fn_801A657C.c
@@ -1,6 +1,6 @@
-extern float lbl_80650DBC;
-extern float lbl_80650DC0;
-extern float lbl_80650DC4;
+extern const float lbl_80650DBC;
+extern const float lbl_80650DC0;
+extern const float lbl_80650DC4;
 
 float fn_801A657C(int value)
 {

--- a/src/game/game_fn_801ACFE8.c
+++ b/src/game/game_fn_801ACFE8.c
@@ -1,22 +1,47 @@
 typedef unsigned char u8;
-typedef unsigned long u32;
-typedef struct EffectNode { struct EffectNode* next; int state; u8 data[0x16]; u8 flushed; u8 queued; } EffectNode;
-extern int lbl_8064D2FC, lbl_8064C2D0;
+typedef unsigned int u32;
+
+typedef struct EffectNode {
+    struct EffectNode* next;
+    int state;
+    u8 data[0x16];
+    u8 flushed;
+    u8 queued;
+} EffectNode;
+
+extern u32 lbl_8064D2FC;
+extern int lbl_8064C2D0;
 extern EffectNode* lbl_8064D304;
 extern u8 lbl_805E2A5C[];
-extern void fn_801B2428(int), fn_801ACFB0(void), fn_8020D250(void*, int, int), DCFlushRange(void*, u32);
+extern void fn_801B2428(int);
+extern void fn_801ACFB0(void);
+extern void fn_8020D250(void*, int, int);
+extern void DCFlushRange(void*, u32);
+
 void fn_801ACFE8(u32 event)
 {
     EffectNode* node;
     switch (event) {
+    case 1:
+    case 2:
+    case 4:
+    case 8:
+        break;
     case 16:
-        if (lbl_8064D2FC == 0) { fn_801B2428(lbl_8064C2D0); fn_801ACFB0(); }
+        if (lbl_8064D2FC == 0) {
+            fn_801B2428(lbl_8064C2D0);
+            fn_801ACFB0();
+        }
         break;
     case 32:
         node = lbl_8064D304;
         if (node != 0 && node->state == 7) {
-            if (node->queued != 0) fn_8020D250(lbl_805E2A5C, 1, 1);
-            else { node->flushed = 1; DCFlushRange(node, 0x20); }
+            if (node->queued != 0) {
+                fn_8020D250(lbl_805E2A5C, 1, 1);
+            } else {
+                node->flushed = 1;
+                DCFlushRange(node, 0x20);
+            }
         }
         break;
     }

--- a/src/game/game_fn_801B1BA0.c
+++ b/src/game/game_fn_801B1BA0.c
@@ -122,10 +122,8 @@ void fn_801B1BA0(void)
         fn_801B2348(0);
         break;
     case 6: {
-        u32 value = entry->value;
-        u32 compare = value;
-        compare -= 0x00000000;
-        if (compare == 0xFFFF) {
+        int value = entry->value;
+        if (value == 0xFFFF) {
             value = lbl_8064D18C;
         }
         lbl_8064D360 = value;

--- a/tools/externalize_elf_symbol.py
+++ b/tools/externalize_elf_symbol.py
@@ -6,12 +6,30 @@ import struct
 import sys
 from pathlib import Path
 
-require_whole_section = sys.argv[-1:] == ["--require-whole-section"]
-args = sys.argv[:-1] if require_whole_section else sys.argv
+require_whole_section = False
+required_section_symbols = None
+args = [sys.argv[0]]
+for arg in sys.argv[1:]:
+    if arg == "--require-whole-section":
+        require_whole_section = True
+    elif arg.startswith("--require-section-symbols="):
+        if required_section_symbols is not None:
+            raise SystemExit("--require-section-symbols may be specified only once")
+        required_section_symbols = arg.split("=", 1)[1].split(",")
+        if not all(required_section_symbols) or len(set(required_section_symbols)) != len(
+            required_section_symbols
+        ):
+            raise SystemExit("--require-section-symbols needs unique symbol names")
+    else:
+        args.append(arg)
+if require_whole_section and required_section_symbols is not None:
+    raise SystemExit(
+        "--require-whole-section and --require-section-symbols are mutually exclusive"
+    )
 if len(args) not in (3, 5):
     raise SystemExit(
         f"usage: {sys.argv[0]} OBJECT LOCAL_SYMBOL [RETAIL_SYMBOL RETAIL_DOL] "
-        "[--require-whole-section]"
+        "[--require-whole-section | --require-section-symbols=SYMBOL,...]"
     )
 path = Path(args[1])
 target = args[2]
@@ -55,20 +73,20 @@ for section_index in range(section_count):
         continue
 
     symbol_offset = struct.unpack_from(">I", data, header + 0x10)[0]
-    symbol_size = struct.unpack_from(">I", data, header + 0x14)[0]
+    symbol_table_size = struct.unpack_from(">I", data, header + 0x14)[0]
     string_index = struct.unpack_from(">I", data, header + 0x18)[0]
     entry_size = struct.unpack_from(">I", data, header + 0x24)[0]
     string_header = section_offset + string_index * section_size
     string_offset = struct.unpack_from(">I", data, string_header + 0x10)[0]
 
-    for entry in range(symbol_offset, symbol_offset + symbol_size, entry_size):
+    for entry in range(symbol_offset, symbol_offset + symbol_table_size, entry_size):
         name_offset = struct.unpack_from(">I", data, entry)[0]
         name_start = string_offset + name_offset
         name_end = data.index(0, name_start)
         if data[name_start:name_end].decode("ascii") == target:
             symbol_value, symbol_size = struct.unpack_from(">II", data, entry + 4)
             symbol_section = struct.unpack_from(">H", data, entry + 0x0E)[0]
-            if retail_target or require_whole_section:
+            if retail_target or require_whole_section or required_section_symbols:
                 if symbol_size == 0 or symbol_section == 0 or symbol_section >= section_count:
                     raise SystemExit(f"{path}: {target} has no file-backed value")
                 section_header = section_offset + symbol_section * section_size
@@ -85,6 +103,71 @@ for section_index in range(section_count):
                         f"[0x{symbol_value:X}, 0x{symbol_value + symbol_size:X}), "
                         f"section size is 0x{value_section_size:X}"
                     )
+                if required_section_symbols is not None:
+                    required = set(required_section_symbols)
+                    ranges = []
+                    defined_section_symbols = set()
+                    for candidate in range(
+                        symbol_offset, symbol_offset + symbol_table_size, entry_size
+                    ):
+                        candidate_name_offset = struct.unpack_from(">I", data, candidate)[0]
+                        candidate_name_start = string_offset + candidate_name_offset
+                        candidate_name_end = data.index(0, candidate_name_start)
+                        candidate_name = data[
+                            candidate_name_start:candidate_name_end
+                        ].decode("ascii")
+                        candidate_value, candidate_size = struct.unpack_from(
+                            ">II", data, candidate + 4
+                        )
+                        candidate_section = struct.unpack_from(
+                            ">H", data, candidate + 0x0E
+                        )[0]
+                        if candidate_section == symbol_section and candidate_size != 0:
+                            defined_section_symbols.add(candidate_name)
+                        if candidate_name not in required:
+                            continue
+                        if candidate_section != symbol_section or candidate_size == 0:
+                            raise SystemExit(
+                                f"{path}: {candidate_name} is not a nonempty symbol "
+                                f"in {target}'s section"
+                            )
+                        ranges.append(
+                            (candidate_value, candidate_value + candidate_size, candidate_name)
+                        )
+                    found = {name for _, _, name in ranges}
+                    if found != required:
+                        missing = ", ".join(sorted(required - found))
+                        raise SystemExit(f"{path}: required section symbols not found: {missing}")
+                    unexpected = defined_section_symbols - required
+                    if unexpected:
+                        names = ", ".join(sorted(unexpected))
+                        raise SystemExit(
+                            f"{path}: unlisted symbols in removed section: {names}"
+                        )
+                    cursor = 0
+                    for start, end, name in sorted(ranges):
+                        if start < cursor or end <= start:
+                            raise SystemExit(
+                                f"{path}: {name} overlaps another required symbol"
+                            )
+                        padding = data[
+                            value_section_offset + cursor:value_section_offset + start
+                        ]
+                        if any(padding):
+                            raise SystemExit(
+                                f"{path}: nonzero unverified section bytes from "
+                                f"0x{cursor:X} to 0x{start:X}"
+                            )
+                        cursor = end
+                    padding = data[
+                        value_section_offset + cursor:
+                        value_section_offset + value_section_size
+                    ]
+                    if any(padding):
+                        raise SystemExit(
+                            f"{path}: nonzero unverified section bytes from "
+                            f"0x{cursor:X} to 0x{value_section_size:X}"
+                        )
             if retail_target:
                 address_match = re.fullmatch(r".*_([0-9A-Fa-f]{8})", retail_target)
                 if not address_match:

--- a/tools/retarget_elf_relocation.py
+++ b/tools/retarget_elf_relocation.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Retarget one relocation within a split compiler-local ELF constant."""
+
+import re
+import struct
+import sys
+from pathlib import Path
+
+
+if len(sys.argv) != 9:
+    raise SystemExit(
+        "usage: retarget_elf_relocation.py OBJECT LOCAL_SYMBOL LOCAL_ADDEND "
+        "RETAIL_BASE RETAIL_SYMBOL SIZE RELOCATION_TYPE RETAIL_DOL"
+    )
+
+path = Path(sys.argv[1])
+local_name = sys.argv[2]
+local_addend = int(sys.argv[3], 0)
+retail_base = sys.argv[4]
+retail_name = sys.argv[5]
+value_size = int(sys.argv[6], 0)
+relocation_types = {"R_PPC_EMB_SDA21": 109}
+relocation_name = sys.argv[7]
+if relocation_name not in relocation_types:
+    raise SystemExit(f"unsupported relocation type {relocation_name!r}")
+relocation_type = relocation_types[relocation_name]
+retail_dol = Path(sys.argv[8])
+data = bytearray(path.read_bytes())
+
+if data[:6] != b"\x7fELF\x01\x02":
+    raise SystemExit(f"{path}: expected a big-endian ELF32 object")
+if local_addend < 0 or value_size <= 0:
+    raise SystemExit("local addend must be nonnegative and size must be positive")
+
+
+def symbol_address(name: str) -> int:
+    match = re.fullmatch(r".*_([0-9A-Fa-f]{8})", name)
+    if match is None:
+        raise SystemExit(f"invalid addressed retail symbol {name!r}")
+    return int(match.group(1), 16)
+
+
+base_address = symbol_address(retail_base)
+retail_address = symbol_address(retail_name)
+if retail_address - base_address != local_addend:
+    raise SystemExit(
+        f"{retail_name} is not {local_addend:#x} bytes after {retail_base}"
+    )
+
+section_offset = struct.unpack_from(">I", data, 0x20)[0]
+section_size = struct.unpack_from(">H", data, 0x2E)[0]
+section_count = struct.unpack_from(">H", data, 0x30)[0]
+
+symtab_header = None
+for index in range(section_count):
+    header = section_offset + index * section_size
+    if struct.unpack_from(">I", data, header + 4)[0] == 2:  # SHT_SYMTAB
+        if symtab_header is not None:
+            raise SystemExit(f"{path}: expected one symbol table")
+        symtab_header = header
+if symtab_header is None:
+    raise SystemExit(f"{path}: symbol table not found")
+
+symbol_offset = struct.unpack_from(">I", data, symtab_header + 0x10)[0]
+symbol_size = struct.unpack_from(">I", data, symtab_header + 0x14)[0]
+string_index = struct.unpack_from(">I", data, symtab_header + 0x18)[0]
+symbol_entry_size = struct.unpack_from(">I", data, symtab_header + 0x24)[0]
+string_header = section_offset + string_index * section_size
+string_offset = struct.unpack_from(">I", data, string_header + 0x10)[0]
+
+symbols = {}
+for symbol_index, entry in enumerate(
+    range(symbol_offset, symbol_offset + symbol_size, symbol_entry_size)
+):
+    name_offset = struct.unpack_from(">I", data, entry)[0]
+    name_start = string_offset + name_offset
+    name_end = data.index(0, name_start)
+    name = data[name_start:name_end].decode("ascii")
+    if name in (local_name, retail_name):
+        if name in symbols:
+            raise SystemExit(f"{path}: duplicate symbol {name!r}")
+        symbols[name] = (symbol_index, entry)
+
+if local_name not in symbols or retail_name not in symbols:
+    raise SystemExit(f"{path}: required symbols {local_name!r} and {retail_name!r} not found")
+
+local_index, local_entry = symbols[local_name]
+retail_index, retail_entry = symbols[retail_name]
+local_value, local_size = struct.unpack_from(">II", data, local_entry + 4)
+local_section = struct.unpack_from(">H", data, local_entry + 0x0E)[0]
+retail_value = struct.unpack_from(">I", data, retail_entry + 4)[0]
+retail_section = struct.unpack_from(">H", data, retail_entry + 0x0E)[0]
+
+if local_section == 0 or local_section >= section_count:
+    raise SystemExit(f"{path}: {local_name} has no file-backed section")
+if local_addend + value_size > local_size:
+    raise SystemExit(f"{path}: requested value is outside {local_name}")
+if retail_section != local_section or retail_value != local_value + local_addend:
+    raise SystemExit(
+        f"{path}: {retail_name} does not identify offset {local_addend:#x} "
+        f"within {local_name}"
+    )
+
+value_header = section_offset + local_section * section_size
+value_section_type = struct.unpack_from(">I", data, value_header + 4)[0]
+value_section_offset = struct.unpack_from(">I", data, value_header + 0x10)[0]
+value_section_size = struct.unpack_from(">I", data, value_header + 0x14)[0]
+value_start = local_value + local_addend
+if value_section_type == 8 or value_start + value_size > value_section_size:
+    raise SystemExit(f"{path}: requested value has no complete file backing")
+
+dol = retail_dol.read_bytes()
+retail_value_bytes = None
+segments = [(0x00, 0x48, 0x90, 7), (0x1C, 0x64, 0xAC, 11)]
+for off_base, addr_base, size_base, count in segments:
+    for index in range(count):
+        file_offset = struct.unpack_from(">I", dol, off_base + 4 * index)[0]
+        address = struct.unpack_from(">I", dol, addr_base + 4 * index)[0]
+        size = struct.unpack_from(">I", dol, size_base + 4 * index)[0]
+        if address <= retail_address and retail_address + value_size <= address + size:
+            start = file_offset + retail_address - address
+            retail_value_bytes = dol[start:start + value_size]
+            break
+    if retail_value_bytes is not None:
+        break
+if retail_value_bytes is None:
+    raise SystemExit(f"{retail_dol}: address {retail_address:#x} is not file-backed")
+
+local_value_bytes = data[
+    value_section_offset + value_start:value_section_offset + value_start + value_size
+]
+if local_value_bytes != retail_value_bytes:
+    raise SystemExit(
+        f"{path}: value {local_value_bytes.hex()} does not match {retail_name} "
+        f"at {retail_address:#x}: {retail_value_bytes.hex()}"
+    )
+
+matches = 0
+for index in range(section_count):
+    header = section_offset + index * section_size
+    if struct.unpack_from(">I", data, header + 4)[0] != 4:  # SHT_RELA
+        continue
+    relocation_offset = struct.unpack_from(">I", data, header + 0x10)[0]
+    relocation_size = struct.unpack_from(">I", data, header + 0x14)[0]
+    relocation_entry_size = struct.unpack_from(">I", data, header + 0x24)[0] or 12
+    for relocation in range(
+        relocation_offset,
+        relocation_offset + relocation_size,
+        relocation_entry_size,
+    ):
+        info = struct.unpack_from(">I", data, relocation + 4)[0]
+        addend = struct.unpack_from(">i", data, relocation + 8)[0]
+        if (
+            info >> 8 == local_index
+            and (info & 0xFF) == relocation_type
+            and addend == local_addend
+        ):
+            struct.pack_into(">I", data, relocation + 4, (retail_index << 8) | (info & 0xFF))
+            struct.pack_into(">i", data, relocation + 8, 0)
+            matches += 1
+
+if matches != 1:
+    raise SystemExit(
+        f"{path}: expected one {relocation_name} relocation to "
+        f"{local_name}+{local_addend:#x}, found {matches}"
+    )
+
+# The added symbol becomes an undefined reference after its bytes and relocation
+# have been checked. The original local symbol is externalized separately.
+struct.pack_into(">II", data, retail_entry + 4, 0, 0)
+struct.pack_into(">H", data, retail_entry + 0x0E, 0)
+path.write_bytes(data)


### PR DESCRIPTION
## Progress

This PR raises matched code from 29.67% to 30.24%: 682,636 to 695,800 of 2,300,692 code bytes, 4,430 to 4,464 of 8,216 functions, and 4,663 to 4,697 of 6,113 objects. It adds 34 matched functions, 34 matched objects, and 13,164 matched code bytes.

## Current behavior

These 34 functions are marked `NonMatching`. Their source needs type, control-flow, declaration, expression, or function-scoped compiler-control corrections, and each function also depends on compiler-local constant or jump-table data that does not use the retail symbol identity.

Renaming a compiler-local symbol can make a function comparison exact while leaving the object's copied data section in the link. In particular, renaming the four jump tables without removing their `.data` sections adds 476 data bytes and 20 alignment bytes to the linked DOL.

`fn_8009E808` has an additional relocation issue: MWCC emits one eight-byte local constant, while the retail binary identifies the two four-byte values with adjacent symbols.

## New behavior

All 34 functions are marked `Matching`. Guarded post-compile rules verify compiler-local data against the addressed retail symbols, retarget or redefine the corresponding relocations, and remove the copied data sections before linking.

The multi-symbol guard requires every nonempty symbol in a removed section to be listed, rejects overlapping ranges, and rejects nonzero bytes outside the verified ranges. `fn_8009E808` uses a separate guarded step that retargets exactly one relocation from the second half of the local constant to the adjacent retail symbol.

## How

- Correct function signatures, signedness, structure layouts, local lifetimes, expression forms, and switch cases where the existing source differed from the retail code.
- Use named structures and unions for copied vectors, colours, and packed short coordinates.
- Keep the required compiler controls function-scoped and reset them immediately: `global_optimizer` for `fn_80095D10`, `opt_propagation` for `fn_8009E808`, `fn_80174F2C`, and `fn_8017A12C`, and `opt_common_subs` for `fn_80174F2C` and `fn_80192F54`.
- Externalize compiler-local constant sections for 29 functions.
- Externalize and remove jump-table sections for `fn_8006E53C`, `fn_800CF598`, `fn_801ACFE8`, and `fn_801B1BA0`.
- Retarget the split constant relocation in `fn_8009E808` before externalizing its local `.sdata2` section.
- Extend `externalize_elf_symbol.py` with fail-closed multi-symbol section coverage and add `retarget_elf_relocation.py` for the checked split-relocation case.
- Document the reusable matching behavior and rejected alternatives in `docs/matching.md`.

All retail symbol names used by these rules already exist in `config/GEDE01/symbols.txt`.

## Testing

Canonical objdiff and explicit comparison with `function_reloc_diffs=name_address` report exact code size, 100% instructions, and equal relocation names and addresses for every function:

| Function | Bytes | Relocations | Strict result |
| --- | ---: | ---: | --- |
| `fn_8006B0F0` | 208 | 8 | 100%, exact |
| `fn_8007D4D8` | 452 | 23 | 100%, exact |
| `fn_8007F770` | 156 | 12 | 100%, exact |
| `fn_80088F4C` | 424 | 24 | 100%, exact |
| `fn_80090004` | 512 | 46 | 100%, exact |
| `fn_80095D10` | 340 | 9 | 100%, exact |
| `fn_8009E808` | 216 | 9 | 100%, exact |
| `fn_800A3180` | 192 | 8 | 100%, exact |
| `fn_800BB5C4` | 220 | 8 | 100%, exact |
| `fn_800BB9A4` | 224 | 8 | 100%, exact |
| `fn_800BBAF0` | 212 | 8 | 100%, exact |
| `fn_800D9E10` | 284 | 7 | 100%, exact |
| `fn_8006E53C` | 264 | 20 | 100%, exact |
| `fn_800CF598` | 276 | 14 | 100%, exact |
| `fn_8012976C` | 268 | 7 | 100%, exact |
| `fn_8014CA98` | 188 | 12 | 100%, exact |
| `fn_80153A24` | 736 | 15 | 100%, exact |
| `fn_80174F2C` | 568 | 24 | 100%, exact |
| `fn_8017A12C` | 148 | 6 | 100%, exact |
| `fn_8017AC20` | 192 | 10 | 100%, exact |
| `fn_8018680C` | 328 | 10 | 100%, exact |
| `fn_80186F70` | 352 | 4 | 100%, exact |
| `fn_80187BB4` | 576 | 3 | 100%, exact |
| `fn_8018D400` | 648 | 18 | 100%, exact |
| `fn_8018E0D8` | 236 | 7 | 100%, exact |
| `fn_8019120C` | 340 | 6 | 100%, exact |
| `fn_801916D0` | 684 | 32 | 100%, exact |
| `fn_801926EC` | 696 | 9 | 100%, exact |
| `fn_80192F54` | 624 | 12 | 100%, exact |
| `fn_801A2A54` | 96 | 2 | 100%, exact |
| `fn_801A34BC` | 312 | 8 | 100%, exact |
| `fn_801A657C` | 68 | 4 | 100%, exact |
| `fn_801ACFE8` | 164 | 12 | 100%, exact |
| `fn_801B1BA0` | 1,960 | 183 | 100%, exact |

- Aggregate strict evidence: 13,164 code bytes and 588 relocation sites.
- A clean full build passed.
- `build/GEDE01/main.dol` is byte-identical to the retail DOL.
- `build/GEDE01/main.dol` SHA-1: `ea24b6af954876ce072562ff39cdb4c81d32be1f`.
- Each accepted function has exactly one post-compile build edge, and no copied `.data`, `.rodata`, `.sdata`, `.sdata2`, `.bss`, or `.sbss` section remains in its object.
- Both helper scripts reject invalid input without modifying it.
- `python3 tools/legal_audit.py` passed.
- `git diff --check` passed.

## Other

### Approaches that did not work

- `fn_8006B0F0`: modelling the values as an external `Kinds` structure scores 57.98077%. A local initializer without guarded externalization scores 99.51923% and leaves a copied `.rodata` section.
- `fn_8007D4D8`: passing the packed direction word directly from the vector after the structure copy leaves one stack reload and scores 99.0%. Reading the packed word into a named local before the copy matches exactly.
- `fn_8007F770`: the original byte-offset table expression scores 94.10256%. A typed `u32` array index from the known table base matches exactly.
- `fn_80090004`: the earlier source using direct `SceneEntry` indexing scores 89.671875%. Keeping the table's strided `value` column in a named pointer matches exactly; a scoped accessor prevents the required layout calculation from being duplicated in the function body.
- `fn_8009E808`: externalizing the full eight-byte constant as one retail symbol leaves the adjacent symbol's relocation-name difference at 99.9%, despite resolving to the same linked address.
- `fn_8006E53C`, `fn_800CF598`, `fn_801ACFE8`, and `fn_801B1BA0`: renaming the jump-table symbols without removing their `.data` sections makes the function comparisons exact but adds 496 bytes to the linked DOL.
- `fn_80153A24`: declaring `fn_801E8328` variadic adds two `crclr` instructions, producing 744 bytes instead of 736 and scoring 98.91304%.
- `fn_80153A24`: two separate walking descriptor pointers leave the parameter-register allocation at 95.2%. A two-element array holding those two pointers matches exactly.
- `fn_80174F2C`: moving the descriptor assignment out of the helper call with only `opt_common_subs off` produces 556 bytes instead of 568 and scores 96.34507%. Disabling propagation as well and storing the script value in a named `u16` matches with ordinary assignment statements.
- `fn_8017AC20`: the original form relies on a negative left shift and scores 84.583336%. An unsigned mask and a named floating-point scale remove that undefined operation and match exactly.
- `fn_80186F70`: keeping the second loop index block-scoped scores 99.40909%. Giving the two loops separate, clearly named counters with the second counter function-scoped matches exactly.
- `fn_80187BB4`: signed-byte casts add `extsb` instructions and score 91.354164%. The byte differences already promote to `int`; removing those casts matches exactly.
- `fn_801916D0`: replacing the packed coordinate stores with two `memcpy` calls produces 716 bytes instead of 684 and scores 90.34503%.
- `fn_80192F54`: marking its three floating-point globals `const` changes floating-point register allocation and scores 99.45513%.
- `fn_8019120C`: rebasing the input pointer directly scores 97.61176%; retaining separate input and working pointers matches exactly.
- `fn_801ACFE8`: declaring `lbl_8064D2FC` signed scores 98.53658%; the retained `u32` declaration matches its integer-handle use and the retail unsigned comparison.
- `fn_8018E0D8`: a ternary clamp scores 93.7%; the explicit `if`/`else` reproduces the retail control flow.
- `fn_801B1BA0`: alternative compiler optimization settings score 99.3%; the retained source and existing per-file settings match after externalizing both jump tables.
- `fn_801247F8` was not included. Its only exact form converts a live pointer to an integer and performs fabricated pointer arithmetic. Readable pointer-index forms are size-exact at 99.84615%.
