### PR TITLE
Match 79 game functions with interface, layout, and declaration corrections

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -118,6 +118,99 @@ config.custom_build_rules = [
         "description": "EXTERNALIZE $in",
     },
     {
+        "name": "align_game_80008014_data",
+        "command": (
+            "build/binutils/powerpc-eabi-objcopy "
+            "--set-section-alignment .data=4 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "ALIGN DATA $in",
+    },
+    {
+        "name": "externalize_game_801C8224_constants",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @89 lbl_80650FC4 "
+            "orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @92 lbl_80650FB8 "
+            "orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @90 lbl_80650FC8 "
+            "orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@89=lbl_80650FC4 "
+            "--redefine-sym=@92=lbl_80650FB8 "
+            "--redefine-sym=@90=lbl_80650FC8 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_8014549C_conversion_biases",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @58 lbl_80650470 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @60 lbl_80650468 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@58=lbl_80650470 --redefine-sym=@60=lbl_80650468 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_801098C0_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @48 lbl_8064FE68 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@48=lbl_8064FE68 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_8000FDE8_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @21 lbl_8064DCE8 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@21=lbl_8064DCE8 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_80185F10_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @14 lbl_80650A10 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@14=lbl_80650A10 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_801C29BC_unsigned_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @14 lbl_80650F50 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@14=lbl_80650F50 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_8007B828_descriptor",
+        "command": (
+            "build/binutils/powerpc-eabi-objcopy "
+            "--add-symbol=lbl_8064E9B8=.sdata2:4,global,object $in && "
+            "python3 tools/retarget_elf_relocation.py $in @4 4 "
+            "lbl_8064E9B4 lbl_8064E9B8 2 R_PPC_EMB_SDA21 "
+            "orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @4 lbl_8064E9B4 "
+            "orig/GEDE01/sys/main.dol --require-whole-section && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@4=lbl_8064E9B4 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
         "name": "externalize_game_801C8F50_unsigned_bias",
         "command": (
             "python3 tools/externalize_elf_symbol.py $in @18 lbl_80650FB8 orig/GEDE01/sys/main.dol && "
@@ -2536,6 +2629,46 @@ config.custom_build_steps = {
             "inputs": [f"build/{VERSION}/src/game/game_fn_801CE594.o"],
         },
         {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_80008014.data_aligned"],
+            "rule": "align_game_80008014_data",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_80008014.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_801C8224.externalized"],
+            "rule": "externalize_game_801C8224_constants",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_801C8224.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8014549C.externalized"],
+            "rule": "externalize_game_8014549C_conversion_biases",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8014549C.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_801098C0.externalized"],
+            "rule": "externalize_game_801098C0_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_801098C0.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8000FDE8.externalized"],
+            "rule": "externalize_game_8000FDE8_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8000FDE8.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_80185F10.externalized"],
+            "rule": "externalize_game_80185F10_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_80185F10.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_801C29BC.externalized"],
+            "rule": "externalize_game_801C29BC_unsigned_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_801C29BC.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8007B828.externalized"],
+            "rule": "externalize_game_8007B828_descriptor",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8007B828.o"],
+        },
+        {
             "outputs": [f"build/{VERSION}/src/game/game_fn_801C8F50.externalized"],
             "rule": "externalize_game_801C8F50_unsigned_bias",
             "inputs": [f"build/{VERSION}/src/game/game_fn_801C8F50.o"],
@@ -4089,7 +4222,7 @@ config.libs = [
             # fn_80008014 sits at 96.11%: MWCC schedules the loop index copy
             # into the latch instead of the body. See reports/GEDE01/
             # matching-cycle-2026-07-25.md. fn_80008134 is 100%.
-            Object(NonMatching, "game/game_fn_80008014.c"),
+            Object(Matching, "game/game_fn_80008014.c"),
             Object(Matching, "game/game_fn_80008154.c"),
             Object(Matching, "game/game_fn_800082A4.c"),
             Object(Matching, "game/game_fn_80008438.c"),
@@ -4235,7 +4368,7 @@ config.libs = [
             # 16 relocation sites agree. Preserve the real C; do not replace
             # the vector-conversion block with inline assembly.
             Object(
-                NonMatching,
+                Matching,
                 "game/game_fn_8000E96C.c",
                 extra_cflags=["-use_lmw_stmw on"],
             ),
@@ -4266,7 +4399,7 @@ config.libs = [
             # 97.94355%: real C reconstruction has the exact 496-byte
             # size and control flow, but MWCC allocates every long-lived
             # value one callee-saved register below retail.
-            Object(NonMatching, "game/game_fn_8000FDE8.c"),
+            Object(Matching, "game/game_fn_8000FDE8.c"),
             Object(Matching, "game/game_fn_8000FFD8.c"),
             Object(Matching, "game/game_fn_8001007C.c"),
             # 100%: argument 1 is the object id and argument 3 is the value;
@@ -5500,7 +5633,7 @@ config.libs = [
     Object(Matching, "game/game_fn_80066D04.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80066D80.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_80066E78.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_80067180.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_80067180.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8006749C.c"),
     Object(NonMatching, "game/game_fn_800674E4.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80067650.c"),
@@ -5512,7 +5645,7 @@ config.libs = [
     Object(Matching, "game/game_fn_80067A18.c"),
     Object(Matching, "game/game_fn_80067B6C.c"),
     Object(Matching, "game/game_fn_80067BAC.c"),
-    Object(NonMatching, "game/game_fn_80067C20.c"),
+    Object(Matching, "game/game_fn_80067C20.c"),
     Object(Matching, "game/game_fn_80067D30.c"),
     Object(Matching, "game/game_fn_80067DA4.c"),
     Object(Matching, "game/game_fn_80067E24.c"),
@@ -5656,7 +5789,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_800746CC.c"),
     Object(Matching, "game/game_fn_800747CC.c"),
     Object(NonMatching, "game/game_fn_80074864.c"),
-    Object(NonMatching, "game/game_fn_80077704.c"),
+    Object(Matching, "game/game_fn_80077704.c"),
     Object(Matching, "game/game_fn_800777B0.c"),
     Object(Matching, "game/game_fn_8007780C.c"),
     Object(Matching, "game/game_fn_8007785C.c"),
@@ -5685,7 +5818,7 @@ config.libs = [
     Object(Matching, "game/game_fn_8007B3C4.c"),
     Object(Matching, "game/game_fn_8007B540.c"),
     Object(Matching, "game/game_fn_8007B640.c"),
-    Object(NonMatching, "game/game_fn_8007B828.c"),
+    Object(Matching, "game/game_fn_8007B828.c"),
     Object(Matching, "game/game_fn_8007BA3C.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8007BC44.c"),
     Object(Matching, "game/game_fn_8007BCD4.c"),
@@ -5849,7 +5982,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800930B0.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80093148.c"),
     Object(Matching, "game/game_fn_800931D0.c"),
-    Object(NonMatching, "game/game_fn_80093264.c"),
+    Object(Matching, "game/game_fn_80093264.c"),
     Object(Matching, "game/game_fn_800933A0.c"),
     Object(Matching, "game/game_fn_800934A0.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80093B80.c"),
@@ -5861,14 +5994,14 @@ config.libs = [
     Object(Matching, "game/game_fn_800955A4.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80095654.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80095774.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_80095894.c"),
+    Object(Matching, "game/game_fn_80095894.c"),
     Object(Matching, "game/game_fn_80095C20.c"),
     Object(Matching, "game/game_fn_80095D10.c"),
     Object(NonMatching, "game/game_fn_80095E64.c"),
     Object(Matching, "game/game_fn_80095FDC.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80096208.c"),
     Object(Matching, "game/game_fn_80096690.c"),
-    Object(NonMatching, "game/game_fn_80096710.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_80096710.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80096830.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8009697C.c"),
     Object(Matching, "game/game_fn_80096A44.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -5939,7 +6072,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800A17C4.c"),
     Object(Matching, "game/game_fn_800A18AC.c"),
     Object(Matching, "game/game_fn_800A1938.c"),
-    Object(NonMatching, "game/game_fn_800A197C.c"),
+    Object(Matching, "game/game_fn_800A197C.c"),
     Object(Matching, "game/game_fn_800A1A04.c"),
     Object(Matching, "game/game_fn_800A1A24.c"),
     Object(Matching, "game/game_fn_800A1A50.c"),
@@ -5983,7 +6116,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800A2B04.c"),
     Object(Matching, "game/game_fn_800A2B80.c"),
     Object(NonMatching, "game/game_fn_800A2B8C.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_800A2D1C.c"),
+    Object(Matching, "game/game_fn_800A2D1C.c"),
     Object(Matching, "game/game_fn_800A2D78.c"),
     Object(Matching, "game/game_fn_800A2DBC.c"),
     Object(Matching, "game/game_fn_800A2DC8.c"),
@@ -6020,7 +6153,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800A3A10.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_800A3AC4.c"),
     Object(Matching, "game/game_fn_800A3C2C.c"),
-    Object(NonMatching, "game/game_fn_800A3C4C.c"),
+    Object(Matching, "game/game_fn_800A3C4C.c"),
     Object(NonMatching, "game/game_fn_800A3C84.c"),
     Object(Matching, "game/game_fn_800A3D90.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_800A3E94.c"),
@@ -6050,7 +6183,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800A4EC8.c"),
     Object(Matching, "game/game_fn_800A4F44.c"),
     Object(NonMatching, "game/game_fn_800A4F98.c"),
-    Object(NonMatching, "game/game_fn_800A509C.c"),
+    Object(Matching, "game/game_fn_800A509C.c"),
     Object(Matching, "game/game_fn_800A5330.c"),
     Object(Matching, "game/game_fn_800A57D4.c"),
     Object(NonMatching, "game/game_fn_800A5948.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -6431,7 +6564,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800CE3BC.c"),
             # 96.36364% size-exact honest-C reconstruction; remaining
             # differences are an equivalent r4/r5 data/index allocation pair.
-            Object(NonMatching, "game/game_fn_800CE524.c"),
+            Object(Matching, "game/game_fn_800CE524.c"),
             Object(Matching, "game/game_fn_800CE698.c"),
             Object(Matching, "game/game_fn_800CE8B8.c"),
             Object(Matching, "game/game_fn_800CE8E8.c"),
@@ -6452,7 +6585,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800CF598.c"),
             Object(Matching, "game/game_fn_800CF8D0.c"),
             Object(Matching, "game/game_fn_800CF904.c"),
-            Object(NonMatching, "game/game_fn_800CFA3C.c"),
+            Object(Matching, "game/game_fn_800CFA3C.c"),
             Object(NonMatching, "game/game_fn_800CFC04.c"),
             Object(Matching, "game/game_fn_800CFCD4.c"),
             Object(Matching, "game/game_fn_800CFDF4.c"),
@@ -6531,7 +6664,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_800D9278.c"),
             Object(Matching, "game/game_fn_800D93B4.c"),
             Object(NonMatching, "game/game_fn_800D9428.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_800D9614.c"),
+            Object(Matching, "game/game_fn_800D9614.c"),
             Object(Matching, "game/game_fn_800D9AE8.c"),
             Object(Matching, "game/game_fn_800D9BB8.c"),
             Object(Matching, "game/game_fn_800D9BE0.c"),
@@ -6575,7 +6708,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800DC250.c"),
             Object(Matching, "game/game_fn_800DC2B8.c"),
             Object(Matching, "game/game_fn_800DC398.c"),
-            Object(NonMatching, "game/game_fn_800DC3A0.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_800DC3A0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_800DC4D4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_800DC9A8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_800DCBC0.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -6705,7 +6838,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800EEB44.c"),
             Object(Matching, "game/game_fn_800EEC0C.c"),
             Object(NonMatching, "game/game_fn_800EEC44.c"),
-            Object(NonMatching, "game/game_TRKNubMainLoop.c"),
+            Object(Matching, "game/game_TRKNubMainLoop.c", extra_cflags=["-sdata 0"]),
             Object(Matching, "game/game_TRKDestructEvent.c"),
             Object(Matching, "game/game_fn_800EEF1C.c"),
             Object(Matching, "game/game_fn_800EEF34.c"),
@@ -6732,7 +6865,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800F0540.c"),
             Object(Matching, "game/game_fn_800F0B70.c"),
             # Honest C is size-exact; only the range compare's temporary registers differ.
-            Object(NonMatching, "game/game_fn_800F0CC4.c"),
+            Object(Matching, "game/game_fn_800F0CC4.c"),
             Object(Matching, "game/game_fn_800F2820.c"),
             Object(Matching, "game/game_fn_800F28D8.c", extra_cflags=["-sdata 0"]),
             Object(Matching, "game/game_fn_800F29BC.c", extra_cflags=["-sdata 0"]),
@@ -6889,7 +7022,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801096C4.c"),
             Object(Matching, "game/game_fn_80109790.c"),
             Object(Matching, "game/game_fn_80109868.c"),
-            Object(NonMatching, "game/game_fn_801098C0.c"),
+            Object(Matching, "game/game_fn_801098C0.c"),
             Object(Matching, "game/game_fn_80109AD4.c"),
             Object(Matching, "game/game_fn_80109B24.c"),
             Object(Matching, "game/game_fn_80109B94.c"),
@@ -6924,14 +7057,14 @@ config.libs = [
             Object(Matching, "game/game_fn_8010F404.c"),
             # Honest selector test; remaining difference is argument-register
             # scheduling around the three-way selection helper.
-            Object(NonMatching, "game/game_fn_8010F8B0.c"),
+            Object(Matching, "game/game_fn_8010F8B0.c"),
             Object(Matching, "game/game_fn_8010F930.c"),
             # Honest mode update; remaining differences are two equivalent
             # selection-helper schedules.
             Object(Matching, "game/game_fn_8010F9D8.c"),
             # Honest mode dispatch; remaining differences are selection-table
             # argument-register scheduling.
-            Object(NonMatching, "game/game_fn_8010FB5C.c"),
+            Object(Matching, "game/game_fn_8010FB5C.c"),
             # Honest signed selection cursor update; remaining differences are
             # local allocation and branch scheduling in the bounded scan.
             Object(NonMatching, "game/game_fn_8010FC3C.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -6968,7 +7101,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80113D50.c"),
             # Honest table search; the retail unroll assigns shape/entry to
             # r7/r6 while this compiler source shape assigns them to r6/r7.
-            Object(NonMatching, "game/game_fn_80113E48.c"),
+            Object(Matching, "game/game_fn_80113E48.c"),
             Object(Matching, "game/game_fn_80113F54.c"),
             Object(Matching, "game/game_fn_80114048.c"),
             Object(Matching, "game/game_fn_801141B8.c"),
@@ -6989,7 +7122,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80118340.c"),
             # Size-exact behavior-complete C; the remaining eight differences
             # are equivalent volatile-register and indexed-address choices.
-            Object(NonMatching, "game/game_fn_80118370.c"),
+            Object(Matching, "game/game_fn_80118370.c"),
             Object(Matching, "game/game_fn_80118528.c"),
             Object(Matching, "game/game_fn_8011857C.c"),
             Object(NonMatching, "game/game_fn_80118670.c"),
@@ -7247,7 +7380,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80126FE0.c"),
             Object(NonMatching, "game/game_fn_801270DC.c"),
             Object(Matching, "game/game_fn_80127128.c"),
-            Object(NonMatching, "game/game_fn_80127178.c"),
+            Object(Matching, "game/game_fn_80127178.c"),
             Object(Matching, "game/game_fn_80127208.c"),
             Object(Matching, "game/game_fn_8012744C.c"),
             Object(NonMatching, "game/game_fn_801274F4.c"),
@@ -7342,7 +7475,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8012B324.c"),
             Object(Matching, "game/game_fn_8012B344.c"),
             Object(Matching, "game/game_fn_8012B388.c"),
-            Object(NonMatching, "game/game_fn_8012B408.c"),
+            Object(Matching, "game/game_fn_8012B408.c"),
             Object(Matching, "game/game_fn_8012B62C.c"),
             Object(Matching, "game/game_fn_8012B690.c"),
             Object(Matching, "game/game_fn_8012B6FC.c"),
@@ -7405,7 +7538,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8012DC94.c"),
             Object(Matching, "game/game_fn_8012E114.c"),
             Object(Matching, "game/game_fn_8012E19C.c"),
-            Object(NonMatching, "game/game_fn_8012E200.c"),
+            Object(Matching, "game/game_fn_8012E200.c"),
             Object(Matching, "game/game_fn_8012E3AC.c"),
             Object(Matching, "game/game_fn_8012E42C.c"),
             Object(Matching, "game/game_fn_8012E498.c"),
@@ -7435,7 +7568,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80130108.c"),
             Object(Matching, "game/game_fn_80130148.c"),
             Object(Matching, "game/game_fn_8013017C.c"),
-            Object(NonMatching, "game/game_fn_801301B0.c"),
+            Object(Matching, "game/game_fn_801301B0.c"),
             Object(Matching, "game/game_fn_80130214.c"),
             Object(NonMatching, "game/game_fn_80130258.c"),
             Object(Matching, "game/game_fn_801302BC.c"),
@@ -7544,15 +7677,15 @@ config.libs = [
             Object(Matching, "game/game_fn_80138F78.c"),
             Object(Matching, "game/game_fn_80138FE4.c"),
             Object(Matching, "game/game_fn_801390D4.c"),
-            Object(NonMatching, "game/game_fn_8013915C.c"),
+            Object(Matching, "game/game_fn_8013915C.c"),
             Object(Matching, "game/game_fn_801391AC.c"),
             Object(NonMatching, "game/game_fn_801391D4.c"),
             Object(Matching, "game/game_fn_80139298.c"),
             Object(NonMatching, "game/game_fn_801392A8.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_80139464.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80139464.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801396A4.c"),
             Object(Matching, "game/game_fn_8013977C.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_801397F8.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801397F8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80139940.c"),
             Object(NonMatching, "game/game_fn_801399CC.c"),
             Object(NonMatching, "game/game_fn_80139B1C.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -7675,8 +7808,8 @@ config.libs = [
             Object(Matching, "game/game_fn_80145408.c"),
             Object(Matching, "game/game_fn_80145478.c"),
             Object(Matching, "game/game_fn_80145490.c"),
-            Object(NonMatching, "game/game_fn_8014549C.c"),
-            Object(NonMatching, "game/game_fn_80145754.c"),
+            Object(Matching, "game/game_fn_8014549C.c"),
+            Object(Matching, "game/game_fn_80145754.c"),
             Object(Matching, "game/game_fn_80145774.c"),
             Object(Matching, "game/game_fn_80145E3C.c"),
             Object(Matching, "game/game_fn_80145E60.c"),
@@ -7700,7 +7833,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80149220.c"),
             Object(Matching, "game/game_fn_80149360.c"),
             Object(Matching, "game/game_fn_8014939C.c"),
-            Object(NonMatching, "game/game_fn_801493D4.c"),
+            Object(Matching, "game/game_fn_801493D4.c"),
             Object(Matching, "game/game_fn_80149524.c"),
             Object(Matching, "game/game_fn_80149590.c"),
             Object(Matching, "game/game_fn_801495FC.c"),
@@ -7752,7 +7885,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8014B738.c"),
             Object(Matching, "game/game_fn_8014B768.c"),
             Object(Matching, "game/game_fn_8014B76C.c"),
-            Object(NonMatching, "game/game_fn_8014B7B0.c"),
+            Object(Matching, "game/game_fn_8014B7B0.c"),
             Object(Matching, "game/game_fn_8014B888.c"),
             Object(Matching, "game/game_fn_8014B8D0.c"),
             Object(Matching, "game/game_fn_8014B928.c"),
@@ -8290,7 +8423,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80161AA0.c"),
             Object(Matching, "game/game_fn_80161B0C.c"),
             Object(Matching, "game/game_fn_80161B58.c"),
-            Object(NonMatching, "game/game_fn_80161C30.c"),
+            Object(Matching, "game/game_fn_80161C30.c"),
             Object(Matching, "game/game_fn_80161CF8.c"),
             Object(Matching, "game/game_fn_80161D58.c"),
             Object(Matching, "game/game_fn_80161E20.c"),
@@ -8347,7 +8480,7 @@ config.libs = [
                 extra_cflags=["-use_lmw_stmw on"],
             ),
             Object(Matching, "game/game_fn_801649CC.c"),
-            Object(NonMatching, "game/game_fn_80164A64.c"),
+            Object(Matching, "game/game_fn_80164A64.c"),
             Object(Matching, "game/game_fn_80164BE4.c"),
             Object(Matching, "game/game_fn_80164C7C.c"),
             Object(Matching, "game/game_fn_80164D04.c"),
@@ -8867,7 +9000,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8017AD7C.c"),
             Object(Matching, "game/game_fn_8017AE0C.c"),
             Object(Matching, "game/game_fn_8017AE20.c"),
-            Object(NonMatching, "game/game_fn_8017AE90.c"),
+            Object(Matching, "game/game_fn_8017AE90.c"),
             Object(Matching, "game/game_fn_8017AF44.c"),
             Object(Matching, "game/game_fn_8017AF64.c"),
             Object(Matching, "game/game_fn_8017AF78.c"),
@@ -8981,7 +9114,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8017EDB4.c"),
             Object(NonMatching, "game/game_fn_8017EE58.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8017F084.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8017F120.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8017F120.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8017F3B4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8017F700.c"),
             Object(Matching, "game/game_fn_8017F794.c"),
@@ -9015,7 +9148,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8017FF24.c"),
             Object(Matching, "game/game_fn_8017FF40.c"),
             Object(Matching, "game/game_fn_8017FF68.c"),
-            Object(NonMatching, "game/game_fn_8017FF7C.c"),
+            Object(Matching, "game/game_fn_8017FF7C.c"),
             Object(Matching, "game/game_fn_8017FF98.c"),
             Object(Matching, "game/game_fn_8017FFA0.c"),
             Object(Matching, "game/game_fn_8017FFA8.c"),
@@ -9073,7 +9206,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801810A0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801813E4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80181530.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8018163C.c"),
+            Object(Matching, "game/game_fn_8018163C.c"),
             Object(Matching, "game/game_fn_8018168C.c"),
             Object(NonMatching, "game/game_fn_801816D4.c"),
             Object(Matching, "game/game_fn_80181808.c"),
@@ -9099,7 +9232,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_80182514.c"),
             Object(Matching, "game/game_fn_80182798.c"),
             Object(Matching, "game/game_fn_8018284C.c"),
-            Object(NonMatching, "game/game_fn_80182984.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80182984.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80182B84.c"),
             Object(Matching, "game/game_fn_80182BCC.c"),
             Object(Matching, "game/game_fn_80182C68.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9156,7 +9289,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801850FC.c"),
             Object(NonMatching, "game/game_fn_80185108.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801851A0.c"),
-            Object(NonMatching, "game/game_fn_8018524C.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018524C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801853F0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80185494.c"),
             Object(Matching, "game/game_fn_8018549C.c"),
@@ -9171,11 +9304,11 @@ config.libs = [
             Object(Matching, "game/game_fn_80185C64.c"),
             Object(NonMatching, "game/game_fn_80185CA4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80185E0C.c"),
-            Object(NonMatching, "game/game_fn_80185F10.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_80185FD0.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80185F10.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80185FD0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801861C4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801865EC.c"),
-            Object(NonMatching, "game/game_fn_8018666C.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018666C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018680C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80186954.c"),
             Object(Matching, "game/game_fn_801869DC.c"),
@@ -9183,7 +9316,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801869F8.c"),
             Object(Matching, "game/game_fn_80186A58.c"),
             Object(Matching, "game/game_fn_80186A80.c"),
-            Object(NonMatching, "game/game_fn_80186A88.c"),
+            Object(Matching, "game/game_fn_80186A88.c"),
             Object(Matching, "game/game_fn_80186C88.c"),
             Object(Matching, "game/game_fn_80186D74.c"),
             Object(Matching, "game/game_fn_80186E10.c"),
@@ -9203,7 +9336,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80187A34.c"),
             Object(Matching, "game/game_fn_80187A3C.c"),
             Object(Matching, "game/game_fn_80187A44.c"),
-            Object(NonMatching, "game/game_fn_80187A4C.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80187A4C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80187BB4.c"),
             Object(Matching, "game/game_fn_80187DF4.c"),
             Object(NonMatching, "game/game_fn_80187E40.c"),
@@ -9250,7 +9383,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_8018ABD4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018AD14.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018AEB0.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8018B058.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018B058.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018B210.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018B3C8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018B580.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9264,7 +9397,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_8018C118.c"),
             Object(NonMatching, "game/game_fn_8018C2D0.c"),
             Object(Matching, "game/game_fn_8018C540.c"),
-            Object(NonMatching, "game/game_fn_8018C6EC.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018C6EC.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018C79C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018C84C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018C8FC.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9272,7 +9405,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_8018CD18.c"),
             Object(NonMatching, "game/game_fn_8018CEC0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018CFB4.c"),
-            Object(NonMatching, "game/game_fn_8018D020.c"),
+            Object(Matching, "game/game_fn_8018D020.c"),
             Object(Matching, "game/game_fn_8018D0D0.c"),
             Object(Matching, "game/game_fn_8018D160.c"),
             Object(Matching, "game/game_fn_8018D1F0.c"),
@@ -9291,7 +9424,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8018E24C.c"),
             Object(Matching, "game/game_fn_8018E260.c"),
             Object(Matching, "game/game_fn_8018E26C.c"),
-            Object(NonMatching, "game/game_fn_8018E504.c"),
+            Object(Matching, "game/game_fn_8018E504.c"),
             Object(Matching, "game/game_fn_8018E8B8.c"),
             Object(Matching, "game/game_fn_8018E8DC.c"),
             Object(Matching, "game/game_fn_8018E8E4.c"),
@@ -9423,7 +9556,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801966E0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80196784.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_80196918.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_80196B10.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80196B10.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_80196DE4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8019753C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801978F8.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9510,7 +9643,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8019BC48.c"),
             Object(Matching, "game/game_fn_8019BCEC.c"),
             Object(Matching, "game/game_fn_8019BD44.c"),
-            Object(NonMatching, "game/game_fn_8019BDE8.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8019BDE8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8019BFA0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8019C06C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8019C26C.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9529,7 +9662,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8019CEF8.c"),
             Object(Matching, "game/game_fn_8019CFBC.c"),
             Object(Matching, "game/game_fn_8019CFC4.c"),
-            Object(NonMatching, "game/game_fn_8019D030.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8019D030.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8019D34C.c"),
             Object(Matching, "game/game_fn_8019D390.c"),
             Object(Matching, "game/game_fn_8019D50C.c"),
@@ -9813,13 +9946,13 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801A8024.c"),
             Object(Matching, "game/game_fn_801A8070.c"),
             Object(
-                NonMatching,
+                Matching,
                 "game/game_fn_801A80FC.c",
                 extra_cflags=["-use_lmw_stmw on"],
             ),
             Object(Matching, "game/game_fn_801A8168.c"),
             Object(
-                NonMatching,
+                Matching,
                 "game/game_fn_801A81FC.c",
                 extra_cflags=["-use_lmw_stmw on"],
             ),
@@ -9853,7 +9986,7 @@ config.libs = [
             ),
             Object(Matching, "game/game_fn_801A8A18.c"),
             Object(Matching, "game/game_fn_801A8B40.c"),
-            Object(NonMatching, "game/game_fn_801A8C60.c"),
+            Object(Matching, "game/game_fn_801A8C60.c"),
             Object(Matching, "game/game_fn_801A8CCC.c"),
             Object(Matching, "game/game_fn_801A8D38.c"),
             Object(
@@ -10092,7 +10225,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801B3940.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B399C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             # Honest C; the remaining divergence is even-path r3 versus r5 allocation.
-            Object(NonMatching, "game/game_fn_801B3A2C.c", mw_version="GC/1.2.5n"),
+            Object(Matching, "game/game_fn_801B3A2C.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801B3B08.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801B3C14.c", mw_version="GC/1.2.5n"),
             Object(NonMatching, "game/game_fn_801B3CC8.c", mw_version="GC/1.2.5n"),
@@ -10124,9 +10257,9 @@ config.libs = [
             Object(Matching, "game/game_fn_801B7A10.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801B7A7C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B7D94.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B7DC8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B7E84.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B7F6C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B7DC8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B7E84.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B7F6C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B8054.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B80D8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801B8164.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
@@ -10140,17 +10273,17 @@ config.libs = [
             Object(Matching, "game/game_fn_801B8CA8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B8D00.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B8D68.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B8D88.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B8DE8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B8D88.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B8DE8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B8E48.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B8E88.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B8E88.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B8F0C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B8F50.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B8F84.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B8FE4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B8F84.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B8FE4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801B9078.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B9170.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801B9220.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801B9220.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B9310.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801B9330.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801B9350.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
@@ -10227,7 +10360,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801C09C4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C0ACC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801C0BC8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801C0ED8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801C0ED8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C0F40.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C1038.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801C106C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
@@ -10250,19 +10383,24 @@ config.libs = [
             Object(Matching, "game/game_fn_801C2754.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801C27D0.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801C2980.c", mw_version="GC/1.2.5n"),
-            Object(NonMatching, "game/game_fn_801C29BC.c", mw_version="GC/1.2.5n"),
+            Object(
+                Matching,
+                "game/game_fn_801C29BC.c",
+                mw_version="GC/1.2.5n",
+                extra_cflags=["-Cpp_exceptions on"],
+            ),
             Object(Matching, "game/game_fn_801C2AAC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801C2B00.c", mw_version="GC/1.2.5n"),
+            Object(Matching, "game/game_fn_801C2B00.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801C2D74.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C2D9C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C2EF0.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801C2F34.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801C2F34.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C30D4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C3158.c", mw_version="GC/1.2.5n"),
             Object(NonMatching, "game/game_fn_801C3278.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C3460.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C350C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801C36FC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801C36FC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801C38C0.c", mw_version="GC/1.2.5n"),
             Object(NonMatching, "game/game_fn_801C38CC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C3B30.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-use_lmw_stmw on"]),
@@ -10289,7 +10427,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801C7868.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801C79C8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801C8160.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
-            Object(NonMatching, "game/game_fn_801C8224.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off", "-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801C8224.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off", "-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801C8600.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off", "-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801C87DC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off", "-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801C8CC0.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
@@ -10311,7 +10449,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801C9E74.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA240.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA284.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
-            Object(NonMatching, "game/game_fn_801CA288.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
+            Object(Matching, "game/game_fn_801CA288.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(NonMatching, "game/game_fn_801CA484.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA3A4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA3D8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
@@ -10319,8 +10457,8 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801CA59C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA798.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(NonMatching, "game/game_fn_801CA7C0.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
-            Object(NonMatching, "game/game_fn_801CAD90.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
-            Object(NonMatching, "game/game_fn_801CAEB8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
+            Object(Matching, "game/game_fn_801CAD90.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
+            Object(Matching, "game/game_fn_801CAEB8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(NonMatching, "game/game_fn_801CAFAC.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801CB238.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801CB274.c", mw_version="GC/1.2.5n"),
@@ -10346,7 +10484,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801CBE58.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CC13C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CC1AC.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
-            Object(NonMatching, "game/game_fn_801CC24C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
+            Object(Matching, "game/game_fn_801CC24C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CC2E4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CC304.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(NonMatching, "game/game_fn_801CC370.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),

--- a/src/game/game_TRKNubMainLoop.c
+++ b/src/game/game_TRKNubMainLoop.c
@@ -27,6 +27,8 @@ void TRKNubMainLoop(void)
         if (TRKGetNextEvent(&event)) {
             input = 0;
             switch (event.type) {
+            case 0:
+                break;
             case 2:
                 TRKDispatchMessage(TRKGetBuffer(event.buffer));
                 break;

--- a/src/game/game_fn_80008014.c
+++ b/src/game/game_fn_80008014.c
@@ -15,12 +15,14 @@ extern void* lbl_8064C528;
 extern void* lbl_8064C534;
 extern Slot* lbl_8064CFF8;
 
+char lbl_8023BEBC[] = "chars/cin%04d/cin%04d.bin";
+
 extern u8 fn_80054BC4(s32);
 extern void fn_80138894(void);
 extern s32 fn_800F9D4C(char*, const char*, ...);
 extern s32 fn_8021302C(const char*);
 extern void* fn_80138B90(const char*, s32, s32);
-extern void fn_801E85A8(void);
+extern void fn_801E85A8(void*);
 extern void* fn_801E86A0(void*, u32);
 extern u32 fn_801E88E4(void*);
 extern void* fn_80125788(void*);
@@ -30,19 +32,20 @@ extern void fn_8014B928(s32);
 void fn_80008014(s32 arg0, s32 arg1)
 {
     char path[32];
-    void* savedArchive;
+    Slot* slots;
+    u32 offset;
+    u8 index;
     void* savedGroup;
+    void* savedArchive;
+    s32 i;
     void* entry;
     void* inst;
-    u32 i;
-    u8 index;
-    Slot* slots;
 
     index = fn_80054BC4(arg0) + 1;
     lbl_8064C534 = 0;
     fn_80138894();
 
-    fn_800F9D4C(path, "chars/cin%04d/cin%04d.bin", (u8)arg1, (u8)arg1);
+    fn_800F9D4C(path, lbl_8023BEBC, (u8)arg1, (u8)arg1);
     if (fn_8021302C(path) == -1) {
         return;
     }
@@ -51,23 +54,24 @@ void fn_80008014(s32 arg0, s32 arg1)
     savedGroup = lbl_8064C528;
 
     lbl_8064C524 = fn_80138B90(path, 1, 1);
-    fn_801E85A8();
+    fn_801E85A8(lbl_8064C524);
     lbl_8064C528 = fn_801E86A0(lbl_8064C524, 0);
     lbl_8064C534 = fn_801E86A0(lbl_8064C524, index);
     if (lbl_8064C534 != 0) {
-        fn_801E85A8();
+        fn_801E85A8(lbl_8064C534);
     }
 
     if (lbl_8064C528 != 0) {
-        fn_801E85A8();
-        for (i = 0; i < fn_801E88E4(lbl_8064C528); i++) {
-            slots = lbl_8064CFF8;
+        fn_801E85A8(lbl_8064C528);
+        for (i = 0, offset = 0; i < fn_801E88E4(lbl_8064C528);
+                offset += sizeof(Slot), i++) {
+            slots = (Slot*)((u8*)lbl_8064CFF8 + offset);
             entry = fn_801E86A0(lbl_8064C528, i);
             if (entry != 0) {
                 inst = fn_80125788(entry);
                 if (inst != 0) {
                     fn_8012B954(inst);
-                    slots[i].handle = inst;
+                    slots->handle = inst;
                 }
             }
         }

--- a/src/game/game_fn_8000E96C.c
+++ b/src/game/game_fn_8000E96C.c
@@ -34,12 +34,12 @@ extern void* fn_8015C390(s32);
 extern void* fn_8015C2FC(s32);
 extern int fn_8016A598(void*);
 extern void fn_80163BB4(void*, const char*, ...);
-extern int fn_80201B44();
-extern void *fn_80201814();
-extern void *fn_80201BC8();
+extern int fn_80201B44(void);
+extern void* fn_80201814(s32);
+extern void* fn_80201BC8(void*);
 extern void fn_8013F3C0(float (*)[4], const Vec3*, const Vec3*,
-                       float, float, float);
-extern void fn_8013FBE4(void*, void*, void*, s32, s32);
+                       float);
+extern void* fn_8013FBE4(void*, const void*, void*, void*, u32);
 
 s32 fn_8000E96C(void* script)
 {
@@ -73,8 +73,7 @@ s32 fn_8000E96C(void* script)
                 rotation.z = lbl_8064DD00 + entry->z;
                 position = rotation;
                 position.z -= lbl_8064DD04;
-                fn_8013F3C0(matrix, &rotation, &position,
-                            lbl_8064DCF0, rotation.z, lbl_8064DD00);
+                fn_8013F3C0(matrix, &rotation, &position, lbl_8064DCF0);
                 fn_8013FBE4(manager, matrix, result, 0, 0);
             }
         }

--- a/src/game/game_fn_8000FDE8.c
+++ b/src/game/game_fn_8000FDE8.c
@@ -1,80 +1,79 @@
+
+typedef unsigned int u32;
 typedef signed short s16;
 typedef int s32;
-
 #pragma use_lmw_stmw on
-
-typedef struct Vec3 {
+typedef struct Vec3
+{
     float x;
     float y;
     float z;
 } Vec3;
-
-typedef struct Vec3s {
+typedef struct Vec3s
+{
     s16 x;
     s16 y;
     s16 z;
 } Vec3s;
-
 extern const char lbl_8023BEF8[];
 extern const double lbl_8064DCE8;
-extern int fn_8016A598(void*);
-extern void fn_80163BB4(void*, const char*, ...);
-extern double fn_8016A694(void*, int);
-extern void* fn_8016A784(void*, int);
-extern void fn_8016A830(void*, double);
-extern void fn_8016A7D8(void*);
+extern int fn_8016A598(void *);
+extern void fn_80163BB4(void *, const char *, ...);
+extern double fn_8016A694(void *, int);
+extern void *fn_8016A784(void *, int);
+extern void fn_8016A830(void *, double);
+extern void fn_8016A7D8(void *);
 extern s32 fn_801D3C5C(s32);
-extern void fn_80179DB0(Vec3*, Vec3s*);
-extern s32 fn_801DD9D4(s32, s32, Vec3*, float, s32, s32, s32, s32, s32, s32*);
-
-s32 fn_8000FDE8(void* script)
+extern void fn_80179DB0(Vec3 *, Vec3s *);
+extern u32 fn_801DD9D4(s32, s32, Vec3 *, float, s32, s32, s32, s32, s32, s32 *);
+s32 fn_8000FDE8(void *script)
 {
-    register void* info = script;
     s32 count;
     s32 type;
-    Vec3s* position;
+    Vec3s *position;
     s32 fourth;
     s32 fifth;
     float scale;
     s32 seventh;
     s32 eighth;
-    s32 ninth;
+    long long ninth;
     s32 flags;
     Vec3 vector;
     s32 result;
-
-    if (fn_8016A598(info) != 9) {
-        fn_80163BB4(info, lbl_8023BEF8, 9, fn_8016A598(info));
+    if (fn_8016A598(script) != 9) {
+        fn_80163BB4(script, lbl_8023BEF8, 9, fn_8016A598(script));
         return 0;
     }
-
-    count = (s32)fn_8016A694(info, 1);
-    type = (s32)fn_8016A694(info, 2);
-    position = fn_8016A784(info, 3);
-    fourth = (s32)fn_8016A694(info, 4);
-    fifth = (s32)fn_8016A694(info, 5);
-    scale = (float)fn_8016A694(info, 6);
-    seventh = (s32)fn_8016A694(info, 7);
-    eighth = (s32)fn_8016A694(info, 8);
-    ninth = (s32)fn_8016A694(info, 9);
-
+    count = (s32) fn_8016A694(script, 1);
+    type = (s32) fn_8016A694(script, 2);
+    position = fn_8016A784(script, 3);
+    fourth = (s32) fn_8016A694(script, 4);
+    fifth = (s32) fn_8016A694(script, 5);
+    scale = (float) fn_8016A694(script, 6);
+    seventh = (s32) fn_8016A694(script, 7);
+    eighth = (s32) fn_8016A694(script, 8);
+    ninth = (s32) fn_8016A694(script, 9);
     switch (count) {
-    case 3:
-        flags = 0x20000;
-        break;
-    case 4:
-        flags = 0x40000;
-        break;
-    default:
-        flags = 0x10000;
-        break;
+        case 3:
+            flags = 0x20000;
+            break;
+
+        case 4:
+            flags = 0x40000;
+            break;
+
+        default:
+            flags = 0x10000;
+            break;
+
     }
+
     flags |= fn_801D3C5C(type);
     fn_80179DB0(&vector, position);
     if (fn_801DD9D4(flags, count, &vector, scale, fifth, fourth, seventh, eighth, ninth, &result) != 0) {
-        fn_8016A830(info, (double)result);
+        fn_8016A830(script, (double) result);
     } else {
-        fn_8016A7D8(info);
+        fn_8016A7D8(script);
     }
     return 1;
 }

--- a/src/game/game_fn_80048C74.c
+++ b/src/game/game_fn_80048C74.c
@@ -58,7 +58,7 @@ extern int fn_80130718(void);
 extern void fn_80144C4C(void* object);
 extern u8 fn_8013017C(void* object);
 extern void fn_80130434(void* object, u32 value);
-extern void fn_801301B0(void* object, u32 first, u32 second);
+extern int fn_801301B0(void* object, u32 first, u32 second);
 extern void fn_800C2474(void* object, u32 value);
 
 extern int fn_80048A60(void);

--- a/src/game/game_fn_80055350.c
+++ b/src/game/game_fn_80055350.c
@@ -12,7 +12,7 @@ extern void *fn_80201BC8();
 extern int fn_80201B54();
 extern void *fn_80201B8C();
 extern void fn_8011E174(s32 index, s32 value);
-extern void fn_801301B0(void *object, s32 set, s32 clear);
+extern int fn_801301B0(void *object, s32 set, s32 clear);
 extern void fn_801B05E8(s32, s32, s32, s32, s32, s32, s32, s32);
 extern s32 fn_800460EC(void);
 extern void fn_800073D8(s32 value);

--- a/src/game/game_fn_80056374.c
+++ b/src/game/game_fn_80056374.c
@@ -17,7 +17,7 @@ extern void *fn_80049194(void);
 extern int fn_80201B44();
 extern unsigned long long fn_8020123C();
 extern void *fn_801A7778(s32 object);
-extern void fn_801301B0(void *object, s32 set, s32 clear);
+extern int fn_801301B0(void *object, s32 set, s32 clear);
 extern s32 fn_80035FB8(void *context, char *first, char *second, char *third,
                       char *value, char *fourth);
 extern void fn_80201D2C(void *, int);

--- a/src/game/game_fn_80056624.c
+++ b/src/game/game_fn_80056624.c
@@ -18,7 +18,7 @@ extern s32 fn_80035FB8(void *context, char *first, char *second, char *third,
                       char *value, char *fourth);
 extern void fn_8012B344(void*);
 extern u64 fn_802011D4(void *event);
-extern void fn_801301B0(void *object, s32 set, s32 clear);
+extern int fn_801301B0(void *object, s32 set, s32 clear);
 
 s32 fn_80056624(void *context, void *event, u32 *result)
 {

--- a/src/game/game_fn_80067180.c
+++ b/src/game/game_fn_80067180.c
@@ -5,7 +5,10 @@ typedef float f32;
 
 typedef struct Vec3 { f32 x, y, z; } Vec3;
 
-extern s32 lbl_80239044[4];
+typedef struct IndexTable {
+    s32 v[4];
+} IndexTable;
+extern IndexTable lbl_80239044;
 extern Vec3 lbl_80239054;
 extern u8 lbl_802FC5BC[];
 extern f32 lbl_8064E698;
@@ -30,7 +33,7 @@ extern s32 fn_80157FE0();
 extern void fn_80158038();
 extern void fn_8014CBE8();
 extern s32 fn_80067728();
-extern s32 fn_80205868();
+extern u32 fn_80205868();
 extern void fn_8012C5B0();
 extern int fn_80201B44();
 extern s32 fn_8015C910();
@@ -39,24 +42,20 @@ extern unsigned long long fn_8020123C();
 
 void fn_80067180(s32 context)
 {
-    s32 fallback_resource = *(s32 *)(lbl_802FC5BC + 0x18);
+    s32 query[8];
+    IndexTable indices = lbl_80239044;
+    Vec3 fallback_position;
+    Vec3 origin;
     Vec3 fallback_offset = lbl_80239054;
-    s32 indices[4];
+    Vec3 direction;
+    s32 fallback_resource = *(s32 *)(lbl_802FC5BC + 0x18);
     s32 owner_state;
     s32 object;
     s32 owner;
-    s32 actor;
+    u32 actor;
     s32 actor_type;
     s32 i;
-    Vec3 origin;
-    Vec3 direction;
-    Vec3 fallback_position;
-    s32 query[5];
 
-    indices[0] = lbl_80239044[0];
-    indices[1] = lbl_80239044[1];
-    indices[2] = lbl_80239044[2];
-    indices[3] = lbl_80239044[3];
     owner_state = (s32)fn_80201B8C(context);
     object = (s32)fn_80201BC8(context);
     fn_80072354(*(s32 *)(owner_state + 0x90));
@@ -66,10 +65,10 @@ void fn_80067180(s32 context)
     actor_type = fn_8011EB1C(object);
 
     for (i = 0; i < 4; i++) {
-        s32 index = indices[i];
+        s32 index = indices.v[i];
         Vec3 *position;
         s32 effect = -1;
-        s32 target = -1;
+        s32 target;
 
         if (!fn_80066D80(object, index))
             continue;
@@ -87,9 +86,13 @@ void fn_80067180(s32 context)
         fn_8014D478(object, position, &direction, 0x10, 1, &fallback_resource, 7);
 
         if (actor != 0 && (*(u32 *)(actor + 0xB8) & (1U << index))) {
-            if (index == 0) {
+            switch (index) {
+            case 0:
                 fn_801A977C(object, 0x19);
-            } else if (index > 0 && index < 4) {
+                break;
+            case 1:
+            case 2:
+            case 3:
                 fn_801A977C(object, 0x18);
                 if (actor_type == 1) {
                     effect = fn_80158598(fn_80201B54(context), 0);
@@ -102,12 +105,13 @@ void fn_80067180(s32 context)
                     if (target != -1)
                         fn_80158038(effect, target);
                 }
+                break;
             }
+            fn_8014CBE8(context, 0x14, index, lbl_802FC5BC + 0x18);
+            if (fn_80067728(*(u8 *)(owner_state + 0x9F)) &&
+                fn_80205868(object, index, &direction, 0x2000) == 0)
+                fn_8012C5B0(object, index);
         }
-        fn_8014CBE8(context, 0x14, index, lbl_802FC5BC + 0x18);
-        if (fn_80067728(*(u8 *)(owner_state + 0x9F)) &&
-            fn_80205868(object, index, &direction, 0x2000) == 0)
-            fn_8012C5B0(object, index);
     }
 
     if (owner == fn_80201B44()) {

--- a/src/game/game_fn_80067C20.c
+++ b/src/game/game_fn_80067C20.c
@@ -22,7 +22,7 @@ typedef struct ObjectState {
 } ObjectState;
 
 extern s32 lbl_8064C548;
-extern u16 lbl_8064DC88[];
+extern u16 lbl_8064DC88[2];
 extern void *fn_80201B8C();
 #define FN_80201E78_RETURN void
 #define FN_80201E78_PARAMETERS Vec3 *out, void *object
@@ -34,8 +34,8 @@ void fn_80067C20(void *object)
 {
     ObjectState *state;
     RuntimeSlot **installed;
-    Vec3 source;
     Vec3 position;
+    Vec3 source;
     RuntimeSlot *slot;
 
     state = fn_80201B8C(object);
@@ -46,7 +46,7 @@ void fn_80067C20(void *object)
 
     if ((u32)(slot->sound + 0x10000) == 0xFFFF) {
         slot->active = lbl_8064C548;
-        lbl_8064C548 = lbl_8064C548 < 2 ? lbl_8064C548 + 1 : 0;
+        lbl_8064C548 = (lbl_8064C548 >= 2) ? 0 : lbl_8064C548 + 1;
     } else {
         fn_801AC980(slot->sound, 30);
         (*installed)->sound = 0;

--- a/src/game/game_fn_80077704.c
+++ b/src/game/game_fn_80077704.c
@@ -14,19 +14,21 @@ extern int fn_8012FF34(void *, Vec3 *, int, int);
 extern void fn_801302BC(void *, int);
 extern void fn_8011FE64(void *, int);
 
-/* NonMatching: behavior-complete source/target position transfer and activation
- * timer update. Remaining differences are MWCC register allocation and one
- * redundant move in the nested handle-resolution chain. */
 void fn_80077704(void *object)
 {
     void *target;
+    void *runtime;
     u8 *state;
     void *source;
     Vec3 position;
 
     target = fn_80201BC8(object);
-    state = *(u8 **)((u8 *)fn_80201B8C(object) + 0x44);
-    source = fn_80201BC8(fn_80201814(fn_80201C48(fn_80201B94(object))));
+    runtime = fn_80201B8C(object);
+    source = fn_80201B94(object);
+    state = *(u8 **)((u8 *)runtime + 0x44);
+    source = fn_80201C48(source);
+    source = fn_80201814(source);
+    source = fn_80201BC8(source);
     fn_8012FE10(source, 0, &position);
     if (fn_8012FF34(target, &position, 4, 4) != 0) {
         fn_801302BC(target, state[0x1BF] + 0x2D);

--- a/src/game/game_fn_8007B828.c
+++ b/src/game/game_fn_8007B828.c
@@ -39,17 +39,15 @@ extern void fn_80179B64(Vec3 *, void *);
 extern void fn_8019FF5C(EffectParams *);
 extern void fn_801A0008(void);
 
-/* NonMatching: honest reconstruction of the paired directional effects,
- * randomized descriptor fields, and follow-up effect dispatch. */
 void fn_8007B828(Object *object)
 {
+    void (*callback)(void) = fn_801834F0;
     unsigned char descriptor[6] = { 0, 0, 0, 0, 0, 1 };
     Vec3 linked_direction;
     Vec3 direction;
     Vec3 effect_position;
     Vec3 follow_position;
     EffectParams params;
-    void (*callback)(void) = fn_801834F0;
     Vec3 *position = &object->position;
 
     fn_80211A6C(position, object, &direction);

--- a/src/game/game_fn_80093264.c
+++ b/src/game/game_fn_80093264.c
@@ -30,9 +30,10 @@ int fn_80093264(void)
         u16 second;
         u8 last;
     } types;
-    register int result = 0;
-    register u32 i;
-    register u8* type;
+    u8* type;
+    int result = 0;
+    u32 i;
+    int objectId;
 
     types.first = lbl_8064EC80;
     types.second = lbl_8064EC84;
@@ -42,8 +43,8 @@ int fn_80093264(void)
         void* object;
         fn_800DE354();
         object = fn_80201814();
-        i = fn_80201EB8();
-        if (object != 0 && (int)i == lbl_8064D18C) {
+        objectId = fn_80201EB8();
+        if (object != 0 && objectId == lbl_8064D18C) {
             if (!fn_8012DBE8(fn_80201BC8(object), 15, &info) ||
                 ((u8*)&info)[3] >= 25) {
                 return -1;
@@ -52,12 +53,12 @@ int fn_80093264(void)
     }
 
     type = (u8*)&types;
-    for (i = 0; i < 7 && result == 0; i++, type++) {
+    for (i = 0; i < 7 && result == 0; type++, i++) {
         result += fn_800CB098(2, (signed char)*type, -1,
                               lbl_8064D18C, 1, 0);
     }
 
-    ((void*)fn_80201B44());
+    fn_80201B44();
     if (fn_80201814() != 0) {
         switch (fn_80036E50()) {
         case 3:

--- a/src/game/game_fn_80095894.c
+++ b/src/game/game_fn_80095894.c
@@ -24,7 +24,7 @@ int fn_80095894(register void* object, void* unused,
 
     runtime = ((Runtime80095894*)fn_80201B8C(object));
     timer = context->timer;
-    context->timer = (timer - 1) & ((-timer & ~timer) >> 31);
+    context->timer = timer > 0 ? timer - 1 : 0;
     if (fn_800931D0(object, state, context) ||
         fn_80092C30(object, runtime->target) || context->timer == 0) {
         fn_80201D2C(object, 1);

--- a/src/game/game_fn_80096710.c
+++ b/src/game/game_fn_80096710.c
@@ -61,9 +61,8 @@ int fn_80096710(void* arg_object, int arg_index,
 
     owner = fn_801294DC(owner, 0xA7, 0x30, 6);
     if (owner != 0) {
-        int packed = index << 8;
-        fn_80128C44(owner, fn_80204810, packed | 7);
-        fn_80128C28(owner, fn_80204810, packed | 0xDB);
+        fn_80128C44(owner, fn_80204810, (index << 8) | 7);
+        fn_80128C28(owner, fn_80204810, (index << 8) | 0xDB);
         *(short*)(state_b->record + 0x30) = candidate->value;
         fn_80201D2C(object, 0x6D);
         fn_80201D14(object, 1);

--- a/src/game/game_fn_800A197C.c
+++ b/src/game/game_fn_800A197C.c
@@ -31,7 +31,8 @@ int fn_800A197C(void)
     void* object;
 
     fn_80204844(fn_80201B9C(), 0x20);
-    transform = (Transform800A197C*)fn_8006D444();
+    context = fn_8006D444();
+    transform = (Transform800A197C*)context;
     context = (Context800A197C*)transform;
     fn_80201814(context->resource);
     object = fn_80201BC8();

--- a/src/game/game_fn_800A2D1C.c
+++ b/src/game/game_fn_800A2D1C.c
@@ -2,18 +2,18 @@ typedef unsigned char u8;
 
 typedef struct Object800A2D1C {
     u8 pad000[0x160];
-    unsigned int handle;
+    void* handle;
 } Object800A2D1C;
 
-extern void* fn_8017FEA4(void);
-extern void fn_8017FF14(unsigned int, void*);
-extern void fn_80186A58(unsigned int, int);
+extern int fn_8017FEA4(void*);
+extern void fn_8017FF14(void*, int);
+extern void fn_80186A58(u8*, int);
 
 void fn_800A2D1C(Object800A2D1C* object)
 {
     if (object->handle != 0) {
-        void* runtime = fn_8017FEA4();
-        fn_8017FF14(object->handle, (u8*)runtime + 0x3C);
+        int runtime = fn_8017FEA4(object->handle);
+        fn_8017FF14(object->handle, runtime + 0x3C);
         fn_80186A58(object->handle, 0);
         object->handle = 0;
     }

--- a/src/game/game_fn_800A3C4C.c
+++ b/src/game/game_fn_800A3C4C.c
@@ -1,9 +1,10 @@
 typedef unsigned char u8;
 
 typedef struct Object800A3C4C Object800A3C4C;
+typedef void (*Callback800A3C4C)(Object800A3C4C*, void*, int, int);
 typedef struct Vtable800A3C4C {
     u8 pad0[0x28];
-    void (*callback)();
+    Callback800A3C4C callback;
 } Vtable800A3C4C;
 
 struct Object800A3C4C {
@@ -20,11 +21,11 @@ typedef struct Wrapper800A3C4C {
  * nested object and vtable while this split TU selects r6/r5.
  * Objdiff: 98.21429%, 56/56 bytes, with no relocations on either side.
  */
-void fn_800A3C4C(void* argument, Wrapper800A3C4C* wrapper)
+void fn_800A3C4C(void* argument, Wrapper800A3C4C* wrapper, int first, int second)
 {
     Object800A3C4C* object = wrapper->object;
     Vtable800A3C4C* vtable = object->vtable;
-    void (*callback)() = vtable->callback;
+    Callback800A3C4C callback = vtable->callback;
 
-    callback(object, argument);
+    callback(object, argument, first, second);
 }

--- a/src/game/game_fn_800A509C.c
+++ b/src/game/game_fn_800A509C.c
@@ -1,9 +1,14 @@
 typedef unsigned char u8;
 typedef unsigned int u32;
 
+typedef struct Owner800A509C {
+    u8 pad0[0xBC];
+    void* previous;
+} Owner800A509C;
+
 typedef struct Runtime800A509C {
     u8 pad0[0x8C];
-    void* owner;
+    Owner800A509C* owner;
     u8 pad90[0xE];
     u8 state;
     u8 active;
@@ -14,9 +19,10 @@ typedef struct Local800A509C {
     float scale;
     u32 kind;
     u32 mode;
-    u8 pad18[0x14];
+    u8 pad18[0x10];
     u32 count;
     int value;
+    u8 pad30[4];
 } Local800A509C;
 
 extern int lbl_8064C4E4;
@@ -64,12 +70,12 @@ extern void fn_801A7864(int);
 void fn_800A509C(int mode)
 {
     Local800A509C local;
-    int original = fn_80201B44();
     void* object;
     void* context;
     Runtime800A509C* runtime;
     void* created;
     void* createdContext;
+    int original = fn_80201B44();
     void* callback;
     int handle;
 
@@ -115,9 +121,8 @@ void fn_800A509C(int mode)
     fn_80201D54(created, local.value);
     fn_80201D3C(created, 0);
     runtime->state = 1;
-    runtime->owner = (void*)original;
-    ((void*)fn_80201B54(created));
-    fn_80201AF8((int)created);
+    runtime->owner->previous = (void*)original;
+    fn_80201AF8(fn_80201B54(created));
     fn_802015A4(created);
 
     callback = fn_80156DA0(3, &local);

--- a/src/game/game_fn_800CE524.c
+++ b/src/game/game_fn_800CE524.c
@@ -32,29 +32,25 @@ extern void *fn_80201B8C();
 
 void fn_800CE524(void *object)
 {
-    int index;
     Data *data = ((RuntimeState *)fn_80201B8C(object))->data;
+    int index = lbl_8064D738;
     s16 span = data->span;
-    Entry *entry;
-    u8 *entries = (u8 *)data + 0x78;
+    Entry *entries = (Entry *)((u8 *)data + 0x78);
     s16 first;
     s16 second;
-
-    index = lbl_8064D738;
 
     data->cursor++;
     if (data->cursor > 480) {
         data->cursor = 0;
     }
-    entry = (Entry *)(entries + index * sizeof(Entry));
     first = data->cursor;
     second = first + span;
-    entry->first_a = first;
-    entry->neg_a = -1;
-    entry->first_b = first;
-    entry->neg_b = -1;
-    entry->second_a = second;
-    entry->neg_c = -1;
-    entry->second_b = second;
-    entry->neg_d = -1;
+    entries[index].first_a = first;
+    entries[index].neg_a = -1;
+    entries[index].first_b = first;
+    entries[index].neg_b = -1;
+    entries[index].second_a = second;
+    entries[index].neg_c = -1;
+    entries[index].second_b = second;
+    entries[index].neg_d = -1;
 }

--- a/src/game/game_fn_800CFA3C.c
+++ b/src/game/game_fn_800CFA3C.c
@@ -1,26 +1,24 @@
+
 typedef signed short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
-
-typedef struct Entry {
+typedef struct Entry
+{
     s16 id;
     u16 value2;
     u16 value4;
     u16 value6;
 } Entry;
-
 extern Entry lbl_805FAA60[10];
 extern u8 lbl_80300368[];
 extern int lbl_8064D18C;
-
-extern void* fn_80201B3C();
+extern void *fn_80201B3C();
 extern int fn_80201EB8();
 extern void fn_8016AFB0(s16);
 extern void fn_8016ADF0(s16, s16, s16);
 extern void *memcpy(void *, const void *, unsigned long);
 extern void fn_8011E98C(void *);
 extern void fn_8011E800(int);
-
 #pragma use_lmw_stmw on
 void fn_800CFA3C(void *state, Entry *entries, void *stream)
 {
@@ -29,17 +27,15 @@ void fn_800CFA3C(void *state, Entry *entries, void *stream)
     Entry *entry;
     int special = 0;
     void *object;
-
     object = fn_80201B3C(state);
-    if (object != 0 && fn_80201EB8(object) != lbl_8064D18C) {
+    if ((object != 0) && (fn_80201EB8(object) != lbl_8064D18C)) {
         special = 1;
     }
-
     global = lbl_805FAA60;
-    i = 0;
     entry = global;
+    i = 0;
     while (i < 10) {
-        if (entry->value6 == 0 && (entry->value4 == 0 || special != 0)) {
+        if ((entry->value6 == 0) && ((entry->value4 == 0) || (special != 0))) {
             fn_8016AFB0(entry->id);
         }
         i++;
@@ -49,16 +45,18 @@ void fn_800CFA3C(void *state, Entry *entries, void *stream)
     i = 0;
     entry = entries;
     while (i < 10) {
-        int found = 0;
         int j;
-        for (j = 0; j < 10; j++) {
-            if (global[j].id == entry->id) {
+        Entry *g = global;
+        int found = 0;
+        for (j = 0; j < 10; j++, g++) {
+            if (g->id == entry->id) {
                 found = 1;
                 break;
             }
         }
+
         if (!found) {
-            fn_8016ADF0(entry->id, (s16)entry->value2, (s16)entry->value4);
+            fn_8016ADF0(entry->id, (s16) entry->value2, (s16) entry->value4);
         }
         i++;
         entry++;

--- a/src/game/game_fn_800D9614.c
+++ b/src/game/game_fn_800D9614.c
@@ -32,8 +32,8 @@ int fn_800D9614(void *unused, void *object)
         if ((actor->flags & 8) == 0) {
             actor->flags |= 8;
             actor->handle = fn_801D5898(actor->position, actor->direction,
-                runtime->resource, 8, 0, 0, 6, 0x40, 0x20, 4, 16, 4, 1,
-                17, 10, 30, 4);
+                runtime->resource, 0, 0, 6, 0x40, 0x20, 16, 4, 1, 17, 10, 30, 4,
+                8, 0x30000);
         }
     }
     return 1;

--- a/src/game/game_fn_800DC3A0.c
+++ b/src/game/game_fn_800DC3A0.c
@@ -57,7 +57,7 @@ void fn_800DC3A0(EffectState *state, int owner, Position *position, int value,
         count = count_arg;
         state->duration = count * 100;
         state->update = fn_801FDC24;
-        state->sequence = sequence_arg;
+        state->sequence = (s16)sequence_arg;
         state->kind = 3;
         state->mode = 15;
         state->source = owner;

--- a/src/game/game_fn_800F0CC4.c
+++ b/src/game/game_fn_800F0CC4.c
@@ -11,9 +11,9 @@ extern int fn_800EF86C(TRKBuffer *, u8 *);
 extern int fn_800EF6EC(TRKBuffer *, u32 *);
 extern int fn_800EFC9C(TRKBuffer *, int);
 extern int fn_800EF2A0(TRKBuffer *);
-extern int fn_800F3C98(u8);
+extern int fn_800F3C98(u8, u32, u32);
 
-static void append(TRKBuffer *buffer, u8 value)
+static inline void append(TRKBuffer *buffer, u8 value)
 {
     if (buffer->position < 0x880) {
         buffer->data[buffer->position++] = value;
@@ -25,8 +25,8 @@ void fn_800F0CC4(TRKBuffer *buffer)
 {
     u32 start;
     u32 end;
-    u8 unused;
-    u8 command;
+    u8 message_command;
+    u8 options;
     int result;
     int retry;
 
@@ -44,8 +44,8 @@ void fn_800F0CC4(TRKBuffer *buffer)
     }
 
     fn_800EFC6C(buffer, 0);
-    result = fn_800EF86C(buffer, &unused);
-    if (result == 0) result = fn_800EF86C(buffer, &command);
+    result = fn_800EF86C(buffer, &message_command);
+    if (result == 0) result = fn_800EF86C(buffer, &options);
     if (result == 0) result = fn_800EF6EC(buffer, &start);
     if (result == 0) result = fn_800EF6EC(buffer, &end);
 
@@ -63,7 +63,7 @@ void fn_800F0CC4(TRKBuffer *buffer)
     }
 
     if (result == 0)
-        result = fn_800F3C98(command);
+        result = fn_800F3C98(options, start, end);
 
     if (result == 0) {
         fn_800EFC9C(buffer, 1);

--- a/src/game/game_fn_800F3C98.c
+++ b/src/game/game_fn_800F3C98.c
@@ -1,6 +1,8 @@
+typedef unsigned char u8;
+
 extern void fn_800F35AC(void *, unsigned int);
 
-int fn_800F3C98(void *unused, unsigned int start, unsigned int end)
+int fn_800F3C98(u8 options, unsigned int start, unsigned int end)
 {
     if (start < end) {
         fn_800F35AC((void *)start, end - start);

--- a/src/game/game_fn_801098C0.c
+++ b/src/game/game_fn_801098C0.c
@@ -20,6 +20,7 @@ extern float lbl_8064FE64;
 #define U16(p, o) (*(u16*)((u8*)(p) + (o)))
 #define U32(p, o) (*(u32*)((u8*)(p) + (o)))
 
+#pragma opt_common_subs off
 int fn_801098C0(void* source, void* state)
 {
     u32 format;
@@ -64,7 +65,7 @@ int fn_801098C0(void* source, void* state)
         return 1;
     }
 
-    U32(state, 0x184) = (u32)(lbl_8064FE60 + (float)U32(state, 0x24) / lbl_8064FE64);
+    U32(state, 0x184) = (int)(lbl_8064FE60 + (float)U32(state, 0x24) / lbl_8064FE64);
     U32(state, 0x180) = 0;
     U16(state, 0x19C) = U16(state, 0xA4);
     U16(state, 0x19E) = U16(state, 0xA6);
@@ -78,3 +79,4 @@ int fn_801098C0(void* source, void* state)
     U32(state, 0x14C) = (u32)state + 0x12C;
     return 0;
 }
+#pragma opt_common_subs reset

--- a/src/game/game_fn_8010F8B0.c
+++ b/src/game/game_fn_8010F8B0.c
@@ -18,7 +18,6 @@ int fn_8010F8B0(int index)
         return 1;
     }
 
-    value = fn_801E8D34(lbl_80331738[2]);
-    value = fn_801E7B24(lbl_8024E388, 3, value);
+    value = fn_801E7B24(lbl_8024E388, 3, fn_801E8D34(lbl_80331738[2]));
     return fn_801E79FC((void *)lbl_8024E388[index], value);
 }

--- a/src/game/game_fn_8010FB5C.c
+++ b/src/game/game_fn_8010FB5C.c
@@ -22,8 +22,8 @@ void fn_8010FB5C(int value)
         fn_801E8B6C(lbl_80331738[0], value);
         break;
     case 2:
-        selection = fn_801E7B24(lbl_8024E388, 3,
-                                fn_801E8D34(lbl_80331738[2]));
+        selection = fn_801E8D34(lbl_80331738[2]);
+        selection = fn_801E7B24(lbl_8024E388, 3, selection);
         if (fn_801E7AD0(lbl_8024E388, 3, selection) > 1 ||
             (fn_80201B44(), fn_80201814(), fn_8020216C() & 0x80000)) {
             fn_801E8B6C(lbl_8064CCF0, value);

--- a/src/game/game_fn_80113E48.c
+++ b/src/game/game_fn_80113E48.c
@@ -1,13 +1,12 @@
-extern const unsigned int lbl_8023A414[12];
 
+extern const unsigned int lbl_8023A414[12];
 int fn_80113E48(unsigned int value)
 {
     unsigned int required = value & 0x00070000;
-    unsigned int shape = value & 0x00003FF0;
     const unsigned int *entry_ptr;
     unsigned int entry;
+    unsigned int shape = value & 0x00003FF0;
     int i;
-
     if ((value & 0xF) == 0) {
         return -1;
     }
@@ -15,11 +14,12 @@ int fn_80113E48(unsigned int value)
         return -1;
     }
     entry_ptr = lbl_8023A414;
-    for (i = 0; i < 12; i++, entry_ptr++) {
+    for (i = 0; i < 12; entry_ptr++, i++) {
         entry = *entry_ptr;
-        if ((entry & required) == required && shape == (entry & 0x3FF0)) {
+        if (((entry & required) == required) && (shape == (entry & 0x3FF0))) {
             return i;
         }
     }
+
     return -1;
 }

--- a/src/game/game_fn_80118370.c
+++ b/src/game/game_fn_80118370.c
@@ -8,8 +8,8 @@ extern unsigned char *lbl_8064C51C;
 extern unsigned char *lbl_8064C5CC;
 extern void fn_8015DAB0(void *);
 extern int lbl_8064D184;
-extern unsigned int lbl_8064CDE0;
-extern int lbl_8064CDA0;
+extern volatile unsigned int lbl_8064CDE0;
+extern volatile int lbl_8064CDA0;
 extern int lbl_8064CDA8;
 extern void *lbl_8064D158;
 extern unsigned int fn_801E7998(void *);
@@ -49,7 +49,8 @@ void fn_80118370(int value, void *resource)
         lbl_8064CDA8 = 1;
         if (lbl_8064D184 >= 0 &&
             (unsigned int)lbl_8064D184 < fn_801E7998(lbl_8064D158)) {
-            int entry = ((struct Entry *)lbl_8064CDE4)[lbl_8064D184].value;
+            struct Entry *slot = (struct Entry *)lbl_8064CDE4;
+            int entry = slot[lbl_8064D184].value;
             if (entry > 0 && entry < 16) {
                 fn_800F9D4C(name, (const char *)lbl_8024E3A4, entry);
                 lbl_8064CDE0 = (unsigned int)lbl_8064CD90 +

--- a/src/game/game_fn_80127178.c
+++ b/src/game/game_fn_80127178.c
@@ -17,8 +17,8 @@ typedef struct State {
 } State;
 
 typedef struct Pair {
-    void* entries;
     u32 count;
+    void* entries;
 } Pair;
 
 #define FN_80128E30_RETURN Runtime*
@@ -28,17 +28,17 @@ extern void fn_80127128(void*, u32, State*, int, int*);
 
 void fn_80127178(Owner* owner, int index, int direction)
 {
-    void* entries;
+    u32 count;
     State* state;
-    volatile Pair* pair;
+    Pair* pair;
     Runtime* runtime;
 
     runtime = fn_80128E30(owner);
-    pair = (volatile Pair*)((u8*)*(void**)((u8*)runtime->table + 4) + index * 8 + 0x10);
-    entries = pair->entries;
-    if (entries != 0) {
+    pair = (Pair*)((u8*)*(void**)((u8*)runtime->table + 4) + index * 8 + 0x10);
+    count = pair->count;
+    if (count != 0) {
         state = (State*)((u8*)owner->states + index * 0x18);
-        fn_80127128(entries, pair->count, state, direction, (int*)state);
+        fn_80127128(pair->entries, count, state, direction, (int*)state);
     }
     state = (State*)((u8*)owner->states + index * 0x18);
     state->direction = direction;

--- a/src/game/game_fn_8012B408.c
+++ b/src/game/game_fn_8012B408.c
@@ -24,8 +24,8 @@ typedef struct Owner8012B408 {
 
 void fn_8012B408(Owner8012B408* owner, Output8012B408* output)
 {
-    int index;
     Entry8012B408* entry;
+    int index;
 
     if (owner->count == 0) {
         return;
@@ -39,6 +39,17 @@ void fn_8012B408(Owner8012B408* owner, Output8012B408* output)
         output->flags = 0;
 
         switch (output->id) {
+        case 142:
+            output->kind = 0x19;
+            break;
+        case 48: case 49: case 50: case 51: case 52:
+            output->flags = 0x40;
+            output->kind = 0x14;
+            break;
+        case 11: case 12:
+        case 69: case 70: case 71:
+            output->kind = 1;
+            break;
         case 0:
             output->flags = 0x40;
             break;
@@ -55,38 +66,31 @@ void fn_8012B408(Owner8012B408* owner, Output8012B408* output)
             output->kind = 0xC;
             break;
         case 4: case 5: case 6: case 7: case 8: case 9:
-        case 65: case 66: case 67: case 68:
+        case 65:
         case 108: case 109: case 110: case 111: case 112: case 113:
             output->flags = 0x20;
             output->kind = 6;
             break;
-        case 11: case 12:
-        case 69: case 70: case 71:
-        case 127: case 144:
-            output->kind = 1;
-            break;
         case 15: case 16: case 17:
-            output->kind = 0x10;
-            output->flags = 0x10;
+            output->flags = output->kind = 0x10;
             break;
-        case 24:
-            output->kind = 6;
-            break;
-        case 48: case 49: case 50: case 51: case 52:
-            output->flags = 0x40;
-            output->kind = 0x14;
-            break;
-        case 76:
-            output->kind = 2;
-            break;
-        case 124:
+        case 127:
             output->kind = 1;
             break;
         case 125:
             output->kind = 8;
             break;
-        case 142:
-            output->kind = 0x19;
+        case 124:
+            output->kind = 1;
+            break;
+        case 24:
+            output->kind = 6;
+            break;
+        case 144:
+            output->kind = 1;
+            break;
+        case 76:
+            output->kind = 2;
             break;
         default:
             output->flags = 0;

--- a/src/game/game_fn_8012E200.c
+++ b/src/game/game_fn_8012E200.c
@@ -17,18 +17,18 @@ typedef struct Vec4 {
 extern void fn_8012BE18(const void*, void*, int);
 extern void fn_8012BE64(const void*, void*);
 extern void fn_802114B8(void*, float, float, float);
-extern void fn_8012E42C(int*, const Vec3*, void*);
+extern void fn_8012E42C(int *, Vec3, void *);
 extern void fn_8012E498(int*, const Vec4*, void*);
 
 int fn_8012E200(u8* entry, int alternate, void* matrix)
 {
     int initialized = 0;
-    Vec3 first_translation;
-    Vec4 first_rotation;
+    Vec3 second_scale;
     Vec3 second_translation;
     Vec4 second_rotation;
     Vec3 first_scale;
-    Vec3 second_scale;
+    Vec3 first_translation;
+    Vec4 first_rotation;
     u16 flags;
 
     if (alternate != 0 && ((flags = *(u16*)(entry + 0xA)) & 0x38) != 0) {
@@ -39,7 +39,7 @@ int fn_8012E200(u8* entry, int alternate, void* matrix)
         }
         if ((*(u16*)(entry + 0xA) & 0x10) != 0) {
             fn_8012BE18(entry + 0x54, &second_translation, 6);
-            fn_8012E42C(&initialized, &second_translation, matrix);
+            fn_8012E42C(&initialized, second_translation, matrix);
         }
         if ((*(u16*)(entry + 0xA) & 8) != 0) {
             fn_8012BE64(entry + 0x6C, &second_rotation);
@@ -53,7 +53,7 @@ int fn_8012E200(u8* entry, int alternate, void* matrix)
         }
         if ((*(u16*)(entry + 0xA) & 2) != 0) {
             fn_8012BE18(entry + 0x54, &first_translation, 6);
-            fn_8012E42C(&initialized, &first_translation, matrix);
+            fn_8012E42C(&initialized, first_translation, matrix);
         }
         if ((*(u16*)(entry + 0xA) & 1) != 0) {
             fn_8012BE64(entry + 0x6C, &first_rotation);

--- a/src/game/game_fn_8012E42C.c
+++ b/src/game/game_fn_8012E42C.c
@@ -6,14 +6,14 @@ typedef struct Vec3 {
 
 extern void fn_80211484(void*, float, float, float);
 
-void fn_8012E42C(int* initialized, const Vec3* value, void* matrix)
+void fn_8012E42C(int* initialized, Vec3 value, void* matrix)
 {
     if (*initialized == 0) {
-        fn_80211484(matrix, value->x, value->y, value->z);
+        fn_80211484(matrix, value.x, value.y, value.z);
     } else {
-        *(float*)((char*)matrix + 0xC) = value->x;
-        *(float*)((char*)matrix + 0x1C) = value->y;
-        *(float*)((char*)matrix + 0x2C) = value->z;
+        *(float*)((char*)matrix + 0xC) = value.x;
+        *(float*)((char*)matrix + 0x1C) = value.y;
+        *(float*)((char*)matrix + 0x2C) = value.z;
     }
     *initialized = 1;
 }

--- a/src/game/game_fn_801301B0.c
+++ b/src/game/game_fn_801301B0.c
@@ -2,7 +2,7 @@ typedef unsigned char u8;
 typedef struct RuntimeState { u8 pad[0x54]; u8 flags; } RuntimeState;
 typedef struct Object { u8 pad[0x290]; RuntimeState* runtime; } Object;
 extern void fn_80125ECC(void *);
-void fn_801301B0(Object* object, u8 clear, u8 set)
+int fn_801301B0(Object* object, u8 clear, u8 set)
 {
     RuntimeState* runtime;
     int value;
@@ -13,4 +13,5 @@ void fn_801301B0(Object* object, u8 clear, u8 set)
     runtime->flags = value & ~clear;
     runtime = object->runtime;
     runtime->flags = runtime->flags | set;
+    return value;
 }

--- a/src/game/game_fn_8013915C.c
+++ b/src/game/game_fn_8013915C.c
@@ -17,13 +17,11 @@ extern void fn_80139464(int);
 
 void fn_8013915C(void)
 {
-    int pending;
     State* state;
 
     state = &lbl_805AE020;
-    pending = state->pending;
-
-    if (pending != -1 && pending != state->slots[state->id].resource_id) {
+    if (state->pending != -1 &&
+        state->pending != state->slots[state->id].resource_id) {
         fn_80139464(state->current);
     }
 }

--- a/src/game/game_fn_801392A8.c
+++ b/src/game/game_fn_801392A8.c
@@ -42,7 +42,7 @@ extern char fn_801390D4[];
 extern Entry* fn_80138950(void*, u16);
 extern void fn_80138FE4(int, u32);
 extern void fn_8013915C(void);
-extern void fn_801397F8(u32*, int, int, int);
+extern void* fn_801397F8(u32*, int, int, int);
 extern void fn_80139940(int);
 extern void fn_8015E9EC(u32, void*, u32);
 extern int fn_80213320(int, void*);

--- a/src/game/game_fn_80139464.c
+++ b/src/game/game_fn_80139464.c
@@ -21,59 +21,59 @@ typedef struct State {
 } State;
 
 extern State lbl_805AE020;
-extern int fn_801397F8(u32*, int, int, int);
+extern void* fn_801397F8(u32*, int, int, int);
 extern void fn_801392A8(int, int);
 extern void fn_80139940(int);
 extern void fn_80139E04(void*, void*, void*, int, int);
 
 int fn_80139464(void* object, int id)
 {
-    State* state = &lbl_805AE020;
-    int other = state->current ^ 1;
     int result = 0;
-    int free_slot = -1;
+    int free_slot;
+    int other = lbl_805AE020.current ^ 1;
 
-    state->request = (int)object;
-    state->wanted = id;
+    lbl_805AE020.wanted = id;
+    lbl_805AE020.request = (int)object;
     if (!fn_801397F8(0, 1, 1, 0)) {
         return 0;
     }
 
-    if (state->slots[state->current].id != id && state->slots[other].id != id) {
-        if (state->slots[state->current].flag == 0) {
-            free_slot = state->current;
-        } else if (state->slots[other].flag == 0) {
+    if (lbl_805AE020.slots[lbl_805AE020.current].id != id && lbl_805AE020.slots[other].id != id) {
+        free_slot = -1;
+        if (lbl_805AE020.slots[lbl_805AE020.current].flag == 0) {
+            free_slot = lbl_805AE020.current;
+        } else if (lbl_805AE020.slots[other].flag == 0) {
             free_slot = other;
         }
-        if (free_slot != -1 && state->slots[free_slot].state != 1) {
-            state->slots[free_slot].id = id;
-            state->slots[free_slot].state = 0;
-            state->slots[free_slot].resource = 0;
+        if (free_slot != -1 && lbl_805AE020.slots[free_slot].state != 1) {
+            lbl_805AE020.slots[free_slot].id = id;
+            lbl_805AE020.slots[free_slot].state = 0;
+            lbl_805AE020.slots[free_slot].resource = 0;
         }
     }
 
-    if (state->slots[state->current].state == 0 &&
-        state->slots[state->current].id != -1) {
-        fn_801392A8(state->current, 0);
+    if (lbl_805AE020.slots[lbl_805AE020.current].state == 0 &&
+        lbl_805AE020.slots[lbl_805AE020.current].id != -1) {
+        fn_801392A8(lbl_805AE020.current, 0);
     }
-    if (state->slots[other].state == 0 && state->slots[other].id != -1) {
+    if (lbl_805AE020.slots[other].state == 0 && lbl_805AE020.slots[other].id != -1) {
         fn_801392A8(other, 1);
     }
 
-    if (state->slots[other].id == id && state->slots[other].state == 2) {
-        state->slots[other].flag = 1;
-        fn_80139E04(object, state->slots[other].resource, (char*)state + 0x10,
-                     (int)state->slots[other].size, 0xAA);
-        if (state->slots[other].resource != 0) {
+    if (lbl_805AE020.slots[other].id == id && lbl_805AE020.slots[other].state == 2) {
+        lbl_805AE020.slots[other].flag = 1;
+        fn_80139E04(object, lbl_805AE020.slots[other].resource, (char*)&lbl_805AE020 + 0x10,
+                     (int)lbl_805AE020.slots[other].size, 0xAA);
+        if (lbl_805AE020.slots[other].resource != 0) {
             result = 1;
         }
-    } else if (state->slots[state->current].id == id &&
-               state->slots[state->current].state == 2) {
-        state->slots[state->current].flag = 1;
-        fn_80139E04(object, state->slots[state->current].resource,
-                     (char*)state + 0x10, (int)state->slots[state->current].size,
+    } else if (lbl_805AE020.slots[lbl_805AE020.current].id == id &&
+               lbl_805AE020.slots[lbl_805AE020.current].state == 2) {
+        lbl_805AE020.slots[lbl_805AE020.current].flag = 1;
+        fn_80139E04(object, lbl_805AE020.slots[lbl_805AE020.current].resource,
+                     (char*)&lbl_805AE020 + 0x10, (int)lbl_805AE020.slots[lbl_805AE020.current].size,
                      0xAA);
-        if (state->slots[state->current].resource != 0) {
+        if (lbl_805AE020.slots[lbl_805AE020.current].resource != 0) {
             result = 1;
         }
     }

--- a/src/game/game_fn_801397F8.c
+++ b/src/game/game_fn_801397F8.c
@@ -5,6 +5,7 @@ typedef struct Slot {
     unsigned char pad04[0x3C];
     void* buffer;
     void* resource;
+    unsigned char pad48[8];
 } Slot;
 
 typedef struct State {
@@ -25,12 +26,13 @@ extern int OSDisableInterrupts(void);
 extern void OSRestoreInterrupts(int);
 extern int fn_8020D318(void*, int, int);
 
-int fn_801397F8(u32* out_size, int kind, int owner, int wait)
+void* fn_801397F8(u32* out_size, int kind, int owner, int wait)
 {
     int other = lbl_805AE020.current ^ 1;
     int blocked = 0;
     int enabled = OSDisableInterrupts();
     u32 size;
+    void* buffer;
 
     if (wait != 1 && lbl_8064CFE8 != 0 && lbl_8064CFE4 != owner) {
         OSRestoreInterrupts(enabled);
@@ -58,13 +60,13 @@ int fn_801397F8(u32* out_size, int kind, int owner, int wait)
 
     if (kind == 2) {
         size = 0x19F0C0;
-        (void)lbl_8064CFD8;
+        buffer = lbl_8064CFD8;
     } else {
         size = lbl_805AE020.arena_size;
-        (void)lbl_805AE020.slots[other].buffer;
+        buffer = lbl_805AE020.slots[other].buffer;
     }
     if (out_size != 0) {
         *out_size = size;
     }
-    return 1;
+    return buffer;
 }

--- a/src/game/game_fn_8014549C.c
+++ b/src/game/game_fn_8014549C.c
@@ -1,3 +1,4 @@
+#pragma use_lmw_stmw on
 typedef signed short s16;
 typedef unsigned int u32;
 
@@ -5,11 +6,11 @@ extern s16 fn_80144A2C(u32, s16, s16, int);
 
 u32 fn_8014549C(int index, float scale)
 {
+    int result = 0;
     s16 x = fn_80144A2C(0x30000, 0, 0x7FFF, index);
     s16 y = fn_80144A2C(0xC0000, 0, 0x7FFF, index);
     s16 z = fn_80144A2C(0x300000, 0, 0x7FFF, index);
     s16 w = fn_80144A2C(0xC00000, 0, 0x7FFF, index);
-    u32 result = 0;
     float limit = (float)x * scale;
     if (limit < 0.0f)
         limit = -limit;

--- a/src/game/game_fn_80145754.c
+++ b/src/game/game_fn_80145754.c
@@ -1,13 +1,12 @@
+#pragma opt_propagation off
 int fn_80145754(int kind)
 {
     int result = 0;
-    switch (kind) {
-    case 1:
+
+    if (kind == 1) {
         result += 0x37420;
-        break;
-    default:
-        result = 0x79E0;
-        break;
+        return result;
     }
-    return result;
+    return 0x79E0;
 }
+#pragma opt_propagation reset

--- a/src/game/game_fn_801493D4.c
+++ b/src/game/game_fn_801493D4.c
@@ -10,7 +10,7 @@ typedef struct QueryResult {
     float x;
     float y;
     float z;
-    unsigned char pad2[12];
+    unsigned char pad2[20];
 } QueryResult;
 
 extern int fn_8011F6A4(void*, void*, int, int, QueryResult*, int);

--- a/src/game/game_fn_8014B7B0.c
+++ b/src/game/game_fn_8014B7B0.c
@@ -4,13 +4,15 @@ extern void* lbl_805B4A20[6];
 extern void* lbl_805B4A38[6];
 extern float lbl_806504A8;
 
+typedef struct QueryResult8014B7B0 {
+    u32 words[6];
+} QueryResult8014B7B0;
+
 extern void* fn_8011F130(void*);
 extern float fn_8011F6F8(void*);
-extern unsigned int fn_80143C28(void*, void*, float, float*, float*, float*);
+extern u32 fn_80143C28(void*, void*, float, QueryResult8014B7B0*, void**,
+                       void**);
 
-/* NonMatching: behavior- and size-exact slot query at 99.703705% (216/216
- * bytes). All body instructions and relocations match; retail reserves a
- * 0x50-byte frame while this MWCC reconstruction reserves 0x40 bytes. */
 int fn_8014B7B0(void* object)
 {
     int i;
@@ -22,12 +24,11 @@ int fn_8014B7B0(void* object)
 
     for (i = 0; i < 6; i++) {
         if (lbl_805B4A20[i] != 0 && lbl_805B4A38[i] != 0) {
-            float x;
-            float y;
-            float z;
-            volatile unsigned char retail_frame_pad[16];
+            QueryResult8014B7B0 result;
+            void* firstHit;
+            void* secondHit;
             if (fn_80143C28(owner, lbl_805B4A38[i], radius,
-                            &x, &y, &z) != 0) {
+                            &result, &firstHit, &secondHit) != 0) {
                 return 1;
             }
         }

--- a/src/game/game_fn_80161C30.c
+++ b/src/game/game_fn_80161C30.c
@@ -26,14 +26,14 @@ extern void fn_80161B0C(Collection*, int*);
 
 void fn_80161C30(Collection* collection, int preserve)
 {
+    int bucket_offset;
     int offset;
     int index;
 
     for (index = 0, offset = 0; index < collection->count; offset += 4, index++) {
         Node** link = (Node**)((char*)collection->lists + offset);
-        while (*link != 0) {
-            int bucket_offset;
-            Node* node = *link;
+        Node* node;
+        while ((node = *link) != 0) {
             if (node->state != 0 && preserve == 0) {
                 node->state = 0;
                 link = &node->next;

--- a/src/game/game_fn_80164A64.c
+++ b/src/game/game_fn_80164A64.c
@@ -33,15 +33,13 @@ extern void fn_8015F988(ParserState*, int);
 extern int fn_8015EC10(ParserState*);
 extern void* fn_8016B5CC(void*, void*, unsigned int, char*, int);
 extern void fn_8016437C(Parser*, int);
-extern void fn_80161244(void*, RuntimeObject*, int, int, int*, int);
+extern void fn_80161244(void*, RuntimeObject*, int);
 
 void fn_80164A64(Parser* parser)
 {
     void* allocator = parser->allocator;
     ParserState* state = parser->state;
     RuntimeObject* object = state->object;
-    int index;
-    int* values;
 
     fn_8015F988(state, 0);
     fn_8015EC10(state);
@@ -59,11 +57,7 @@ void fn_80164A64(Parser* parser)
     object->values_2C = fn_8016B5CC(allocator, object->values_2C,
                                     (object->count_30 + 1) * 4,
                                     lbl_8024F8B0, 0x153);
-    index = object->count_30;
-    values = object->values_2C;
-    object->count_30 = index + 1;
-    values[index] = 0x7FFFFFFD;
-    fn_80161244(allocator, object, state->value_10, index,
-                values, 0x7FFFFFFD);
+    object->values_2C[object->count_30++] = 0x7FFFFFFD;
+    fn_80161244(allocator, object, state->value_10);
     parser->state = state->parent;
 }

--- a/src/game/game_fn_8017AE90.c
+++ b/src/game/game_fn_8017AE90.c
@@ -1,6 +1,8 @@
 extern unsigned char lbl_8064A580[];
 extern int lbl_8064D208;
 
+typedef unsigned long long u64;
+
 extern void fn_8017B7C8(void);
 extern void fn_8017B9F8(void);
 extern void fn_8017B7EC(int);
@@ -9,7 +11,7 @@ extern void fn_8017B864(int);
 extern void fn_8017B8BC(int);
 extern void fn_8017B914(int);
 extern void fn_8017B96C(int);
-extern void fn_8017BA54(int, void*);
+extern void fn_8017BA54(u64);
 extern void fn_8017B344(int, int);
 extern void fn_8017BAF4(void);
 
@@ -25,7 +27,7 @@ void fn_8017AE90(void)
     fn_8017B8BC(0);
     fn_8017B914(0);
     fn_8017B96C(0);
-    fn_8017BA54(0, (void*)0);
+    fn_8017BA54(0);
 
     lbl_8064D208 = 0;
     *(int*)(lbl_8064A580 + 0x44) = 0;

--- a/src/game/game_fn_8017BA54.c
+++ b/src/game/game_fn_8017BA54.c
@@ -1,8 +1,10 @@
-extern void* lbl_8064D200;
-extern void* lbl_8064D204;
+typedef unsigned long long u64;
 
-void fn_8017BA54(void* first, void* second)
+extern unsigned int lbl_8064D200;
+extern unsigned int lbl_8064D204;
+
+void fn_8017BA54(u64 value)
 {
-    lbl_8064D204 = second;
-    lbl_8064D200 = first;
+    lbl_8064D204 = (unsigned int)value;
+    lbl_8064D200 = (unsigned int)(value >> 32);
 }

--- a/src/game/game_fn_8017F120.c
+++ b/src/game/game_fn_8017F120.c
@@ -1,49 +1,54 @@
+
 typedef signed short s16;
 typedef unsigned char u8;
 typedef unsigned short u16;
-
-extern void fn_80179904(void*, s16);
-extern void fn_8018E230(void*, void*, int, int, int, int);
+extern void fn_80179904(void *, s16);
+extern void fn_8018E230(void *, void *, int, int, int, int);
 extern void fn_8017F3B4(void);
-
-int fn_8017F120(u8* object)
+inline static s16 read_s16(u8 *p)
 {
-    int i;
-    int count;
-    u8* entry;
+    return *((s16 *) p);
+}
 
+int fn_8017F120(u8 *object) {
+    u8 **slot;
+    u8 count;
+    u8 *entry;
+    int i;
     count = object[1];
-    entry = *(u8**)(object + 0x4C);
-    for (i = 0; i < count; i++, entry += 0x38) {
-        *(s16*)(entry + 0x0A) += *(s16*)(entry + 0x10);
-        *(s16*)(entry + 0x0C) += *(s16*)(entry + 0x12);
+    slot = (u8 **) (object + 0x4C);
+    entry = *slot;
+    for (i = 0; i < count; i++) {
+        *((s16 *) (entry + 0x0A)) += read_s16(entry + 0x10);
+        *((s16 *) (entry + 0x0C)) += read_s16(entry + 0x12);
+        entry += 0x38;
     }
 
-    entry = *(u8**)(object + 0x4C);
-    if (*(u16*)(object + 0x0A) == *(u16*)(entry + 8)) {
-        for (i = 0; i < count; i++, entry += 0x38) {
+    entry = *slot;
+    if ((*((u16 *) (object + 0x0A))) == (*((u16 *) (entry + 8)))) {
+        for (i = 0; i < count; i++) {
             s16 x;
             s16 y;
-
-            *(u16*)(entry + 8) += *(u16*)(object + 0xEC);
-            *(s16*)(entry + 0x14) = 0;
+            *((u16 *) (entry + 8)) += *((u16 *) (object + 0xEC));
+            *((s16 *) (entry + 0x14)) = 0;
             fn_80179904(entry + 0x10, 1);
-            *(s16*)(entry + 0x16) = 0;
-            *(s16*)(entry + 0x18) = 0;
-            *(s16*)(entry + 0x1A) = -1;
-
-            x = *(s16*)(entry + 0x10);
+            *((s16 *) (entry + 0x16)) = 0;
+            *((s16 *) (entry + 0x18)) = 0;
+            *((s16 *) (entry + 0x1A)) = -1;
+            x = read_s16(entry + 0x10);
             if (x != 0) {
-                *(s16*)(entry + 0x16) = x > 0 ? -1 : 1;
+                *((s16 *) (entry + 0x16)) = (x > 0) ? (-1) : (1);
             }
-            y = *(s16*)(entry + 0x12);
+            y = read_s16(entry + 0x12);
             if (y != 0) {
-                *(s16*)(entry + 0x18) = y > 0 ? -1 : 1;
+                *((s16 *) (entry + 0x18)) = (y > 0) ? (-1) : (1);
             }
             fn_8018E230(entry, entry + 0x2B, 1, 0, 5, 250);
+            entry += 0x38;
         }
-        *(void (**)(void))(object + 0x14C) = fn_8017F3B4;
+
+        *((void (**)(void)) (object + 0x14C)) = fn_8017F3B4;
     }
-    (*(u16*)(object + 0x0A))++;
+    (*((u16 *) (object + 0x0A)))++;
     return 0;
 }

--- a/src/game/game_fn_8017FF7C.c
+++ b/src/game/game_fn_8017FF7C.c
@@ -1,5 +1,6 @@
 unsigned int fn_8017FF7C(void* object, int index, int slot)
 {
-    unsigned int (*entries)[14] = *(void**)((char*)object + 0x4C);
-    return entries[index][10 + slot];
+    unsigned char* entries = *(void**)((char*)object + 0x4C);
+    unsigned char* entry = entries + index * 0x38 + 0x28;
+    return *(unsigned int*)(entry + slot * 4);
 }

--- a/src/game/game_fn_8018163C.c
+++ b/src/game/game_fn_8018163C.c
@@ -16,7 +16,7 @@ extern s16 lbl_80606360[];
 void fn_8018163C(Entry* dst, const Coord* src, s16 angle, int scale)
 {
     register int x;
-    register s16 index;
+    register int index;
     index = angle;
     x = src->x;
     dst->position.x = x + ((lbl_80606360[index] * scale) >> 7);

--- a/src/game/game_fn_80182984.c
+++ b/src/game/game_fn_80182984.c
@@ -17,7 +17,7 @@ extern u8 fn_8018E26C(void*, void*);
 extern void fn_8018284C(void*, int);
 extern void fn_80180518(void*, u8, int);
 extern void fn_8017D2B4(void*, void*, void*);
-extern void fn_8018E230();
+extern void fn_8018E230(void*, void*, int, int, s8, u8);
 
 int fn_80182984(u8* self)
 {
@@ -58,7 +58,8 @@ int fn_80182984(u8* self)
                     fn_8017D2B4(entry + 0xA, entry + 0x16, entry + 0x10);
                     index = i;
                     if (config->fields.counters[index] == *(u16*)(entry + 8)) {
-                        fn_8018E230(entry, entry + 0x2B, 1, self[2], self[4], 0);
+                        fn_8018E230(entry, entry + 0x2B, 1, self[2],
+                                    *(s8*)(self + 4), 0);
                     }
                     config->fields.counters[index]++;
                 }

--- a/src/game/game_fn_8018524C.c
+++ b/src/game/game_fn_8018524C.c
@@ -28,10 +28,15 @@ typedef struct Object {
     u8 pad_24[0x28];
     Entry* entries;
     u8 pad_50[0x44];
-    u32 field_94;
+    int field_94;
     u8 position[12];
     u16 flags;
 } Object;
+
+typedef struct Header8018524C {
+    u8 pad00[0xC];
+    u16 flags;
+} Header8018524C;
 
 u32 fn_8018524C(Object* self)
 {
@@ -39,63 +44,64 @@ u32 fn_8018524C(Object* self)
     int old_counter;
     u8* position;
     Entry* entry;
-    Object* saved_self;
     int index;
     Entry* entry1;
+    Entry* current;
     Entry* destination0;
     Entry* source0;
     Entry* destination1;
     Entry* source1;
+    Header8018524C* header;
 
     position = (u8*)self + 0x98;
-    saved_self = (Object*)(position - 0x98);
-    old_counter = saved_self->counter;
-    entry = saved_self->entries;
-    count = saved_self->count;
-    saved_self->counter = old_counter + 1;
+    header = (Header8018524C*)position;
+    old_counter = self->counter;
+    entry = self->entries;
+    count = self->count;
+    entry1 = self->entries + 1;
+    self->counter = old_counter + 1;
 
     destination0 = entry + (count - 2);
-    entry1 = entry + 1;
     destination1 = entry1 + (count - 2);
     source0 = destination0 - 2;
     source1 = destination1 - 2;
 
-    if (saved_self->flags & 1) {
+    if (self->flags & 1) {
         index = (count >> 1) - 1;
         while (index > 0) {
             memcpy(destination0->position, source0->position, 6);
-            memcpy(destination1->position, source1->position, 6);
             destination0 -= 2;
             source0 -= 2;
+            memcpy(destination1->position, source1->position, 6);
             destination1 -= 2;
             source1 -= 2;
             index--;
         }
         memcpy(entry[0].position, position, 6);
         memcpy(entry1->position, position + 6, 6);
-        saved_self->flags &= ~1;
+        header->flags &= ~1;
     }
 
-    if (saved_self->flags & 0x10) {
-        Entry* current = entry;
-        for (index = 0; index < count; index++, current++) {
+    if (header->flags & 0x10) {
+        current = entry;
+        for (index = 0; index < count; current++, index++) {
             if (current->active)
                 fn_8018E26C(current, &current->field_2B);
         }
     }
 
-    if (saved_self->flags & 8) {
-        saved_self->flags |= 0x10;
-        saved_self->flags &= ~8;
-        for (index = 0; index < count; index++, entry++) {
+    if (header->flags & 8) {
+        header->flags |= 0x10;
+        header->flags &= ~8;
+        for (index = 0; index < count; entry++, index++) {
             fn_8018E230(entry, &entry->field_2B, 1, entry->field_2B,
-                        saved_self->field_04, 0);
+                        self->field_04, 0);
         }
     }
 
-    if (saved_self->field_94 == 0 &&
-        ((saved_self->flags & 2) != 0 || old_counter > saved_self->limit)) {
-        saved_self->state = 8;
+    if (self->field_94 == 0 &&
+        ((header->flags & 2) != 0 || old_counter > self->limit)) {
+        self->state = 8;
     }
     return 0;
 }

--- a/src/game/game_fn_80185F10.c
+++ b/src/game/game_fn_80185F10.c
@@ -10,12 +10,12 @@ void fn_80185F10(u8* state, u8* self, u16 count, void* setup)
     void* local_setup = setup;
     register u16 local_count;
     int i;
-    int limit = self[1];
+    u16 limit = self[1];
     u8* entry = *(u8**)(self + 0x4C);
 
     local_count = count;
     *(u16*)(state + 0xE) = local_count;
-    for (limit -= 1, i = 0; i < limit; i++) {
+    for (i = 0; i < limit - 1; i++) {
         fn_8018163C(entry, local_setup,
                     (int)(i * *(float*)(local_state + 0x30)) & 0x3F,
                     local_count);

--- a/src/game/game_fn_80185FD0.c
+++ b/src/game/game_fn_80185FD0.c
@@ -25,7 +25,7 @@ extern void* lbl_8064D738;
 extern u32 lbl_80651D48;
 extern u16 lbl_80651D4C;
 extern float lbl_80650A1C;
-extern float lbl_80650A20;
+extern const float lbl_80650A20;
 
 extern void fn_8018D788(void*, void*, void**, u16);
 extern void fn_801869F8(void*, int, u16);
@@ -40,9 +40,11 @@ int fn_80185FD0(u8* self)
     Locals locals;
     float value;
     int changed = 0;
-    int vector_offset;
+    struct {
+        int offset;
+        int count;
+    } span;
     u8* self_local = self;
-    u8 count;
     u16 generation;
     int index;
     u8* state;
@@ -53,7 +55,7 @@ int fn_80185FD0(u8* self)
     locals.setup.half = lbl_80651D4C;
     generation = *(u16*)(self_local + 0xA);
     entry = *(u8**)(self_local + 0x4C);
-    count = self_local[1];
+    span.count = self_local[1];
     *(u16*)(self_local + 0xA) = generation + 1;
 
     fn_8018D788(lbl_8064D738, self_local, &locals.vectors,
@@ -61,8 +63,8 @@ int fn_80185FD0(u8* self)
     fn_801869F8(state, 0, *(u16*)(state + 8));
 
     index = 0;
-    vector_offset = 0;
-    for (; index < count; index++) {
+    span.offset = 0;
+    for (; index < span.count; index++) {
         if (entry[0] != 0) {
             fn_8018E26C(entry, entry + 0x2B);
             if (changed == 0 && (state[5] & 4) != 0) {
@@ -75,15 +77,15 @@ int fn_80185FD0(u8* self)
             }
         }
         fn_8018680C(state, entry,
-                    (Vec3*)((u8*)locals.vectors + vector_offset),
-                    index, &locals.setup, count);
+                    (Vec3*)((u8*)locals.vectors + span.offset),
+                    index, &locals.setup, span.count);
         if ((int)generation == (int)*(u16*)(entry + 8) &&
             (state[5] & 1) == 0) {
             fn_8018E230(entry, entry + 0x2B, 1, self_local[2],
                         self_local[4], 0);
         }
         entry += 0x38;
-        vector_offset += 0xC;
+        span.offset += 0xC;
     }
 
     fn_80211A48((Vec3*)(state + 0x60), (Vec3*)(state + 0x6C),

--- a/src/game/game_fn_8018666C.c
+++ b/src/game/game_fn_8018666C.c
@@ -20,6 +20,7 @@ void fn_8018666C(u8* self)
     u8* data = lbl_80607120;
     u8 count = self[1];
     u16 size0 = *(u16*)(data + 2);
+    int i;
     u16 flush0 = *(u16*)(data + 0xA);
     u16 flush1 = *(u16*)(data + 0xE);
     u16 flush2 = *(u16*)(data + 0xC);
@@ -27,8 +28,8 @@ void fn_8018666C(u8* self)
     u8* buffer0 = *(u8**)(self + 0x50);
     u8* buffer1 = *(u8**)(self + 0x54);
     u8* buffer2 = *(u8**)(self + 0x58);
-    int i;
     u8* out;
+    u8* fill;
     int entry_index;
     int j;
     int saved;
@@ -49,11 +50,11 @@ void fn_8018666C(u8* self)
         entries += 0x38;
     }
 
-    out = buffer0 + (i << 1) * 6;
+    fill = buffer0 + (i << 1) * 6;
     for (; i < 0x40; i++) {
-        memcpy(out, buffer0, 6);
-        memcpy(out + 6, buffer0 + 6, 6);
-        out += 12;
+        memcpy(fill, buffer0, 6);
+        memcpy(fill + 6, buffer0 + 6, 6);
+        fill += 12;
     }
 
     DCFlushRange(buffer0, flush0);

--- a/src/game/game_fn_80186A88.c
+++ b/src/game/game_fn_80186A88.c
@@ -1,116 +1,103 @@
+
 typedef signed char s8;
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
-
 #pragma use_lmw_stmw on
-
-typedef struct SixBytes {
+typedef struct SixBytes
+{
     u32 word;
     u16 half;
 } SixBytes;
-
-typedef struct Vec3 {
+typedef struct Vec3
+{
     float x;
     float y;
     float z;
 } Vec3;
-
-typedef struct Locals {
+typedef struct Locals
+{
     SixBytes setup;
-    void* vectors;
+    void *vectors;
 } Locals;
-
 extern u8 lbl_80607120[];
-extern void* lbl_8064D738;
+extern void *lbl_8064D738;
 extern u32 lbl_80651D58;
 extern u16 lbl_80651D5C;
-extern float lbl_80650A20;
-
-extern void fn_8018D788(void*, void*, void**, u16);
-extern void fn_801869F8(void*, int, u16);
-extern void fn_8018E26C(void*, void*);
-extern void fn_801865EC(void*, SixBytes*, int);
-extern void fn_80186954(void*, void*, Vec3*, int, SixBytes*);
-extern void fn_8018E230(void*, void*, int, u8, u8, int);
-extern void fn_80211A48(Vec3*, Vec3*, Vec3*);
-extern void fn_80198154(void*, void*, int, int, Vec3*);
-
-int fn_80186A88(u8* self)
+extern const float lbl_80650A20;
+extern void fn_8018D788(void *, void *, void **, u16);
+extern void fn_801869F8(void *, int, u16);
+extern void fn_8018E26C(void *, void *);
+extern void fn_801865EC(void *, SixBytes *, int);
+extern void fn_80186954(void *, void *, Vec3 *, int, SixBytes *);
+extern void fn_8018E230(void *, void *, int, u8, u8, int);
+extern void fn_80211A48(Vec3 *, Vec3 *, Vec3 *);
+extern void fn_80198154(void *, void *, int, int, Vec3 *);
+int fn_80186A88(u8 *self)
 {
     Locals locals;
     int changed = 0;
-    int vector_offset;
-    u8* self_local = self;
-    u8 count;
+    int loop[2];
+    u8 *self_local = self;
     u16 generation;
     int index;
-    u8* state;
-    u8* entry;
+    u8 *state;
+    u8 *entry;
     float component;
-
+    u8 *state_bytes;
     state = self_local + 0x8C;
     locals.setup.word = lbl_80651D58;
     locals.setup.half = lbl_80651D5C;
-    generation = *(u16*)(self_local + 0xA);
-    entry = *(u8**)(self_local + 0x4C);
-    count = self_local[1];
-    *(u16*)(self_local + 0xA) = generation + 1;
-
-    fn_8018D788(lbl_8064D738, self_local, &locals.vectors,
-                *(u16*)(lbl_80607120 + 2));
-    fn_801869F8(state, 0, *(u16*)(state + 8));
-
+    generation = *((u16 *) (self_local + 0xA));
+    entry = *((u8 **) (self_local + 0x4C));
+    loop[1] = self_local[1];
+    *((u16 *) (self_local + 0xA)) = generation + 1;
+    fn_8018D788(lbl_8064D738, self_local, &locals.vectors, *((u16 *) (lbl_80607120 + 2)));
+    fn_801869F8(state, 0, *((u16 *) (state + 8)));
     index = 0;
-    vector_offset = 0;
-    for (; index < count; index++) {
+    loop[0] = 0;
+    for (; index < loop[1]; index++) {
         if (entry[0] != 0) {
             fn_8018E26C(entry, entry + 0x2B);
-            if (changed == 0 && (state[5] & 4) != 0) {
-                if ((s8)state[1] > 2) {
+            if ((changed == 0) && ((state[5] & 4) != 0)) {
+                if (((s8) state[1]) > 2) {
                     state[1]--;
-                } else if ((s8)state[1] < -2) {
+                } else
+                    if (((s8) state[1]) < (-2)) {
                     state[1]++;
                 }
                 changed = 1;
             }
         }
         fn_801865EC(self_local, &locals.setup, index);
-        fn_80186954(state, entry,
-                    (Vec3*)((u8*)locals.vectors + vector_offset),
-                    index, &locals.setup);
-        if ((int)generation == (int)*(u16*)(entry + 8) &&
-            (state[5] & 1) == 0) {
-            fn_8018E230(entry, entry + 0x2B, 1, self_local[2],
-                        self_local[4], 0);
+        fn_80186954(state, entry, (Vec3 *) (((u8 *) locals.vectors) + loop[0]), index, &locals.setup);
+        if ((((int) generation) == ((int) (*((u16 *) (entry + 8))))) && ((state[5] & 1) == 0)) {
+            fn_8018E230(entry, entry + 0x2B, 1, self_local[2], self_local[4], 0);
         }
         entry += 0x38;
-        vector_offset += 0xC;
+        loop[0] += 0xC;
     }
 
-    fn_80211A48((Vec3*)(state + 0x60), (Vec3*)(state + 0x6C),
-                (Vec3*)(state + 0x60));
-    component = *(float*)(state + 0x60);
-    if (component > lbl_80650A20)
-        component = *(float*)(state + 0x6C);
-    *(float*)(state + 0x60) = component;
-    component = *(float*)(state + 0x64);
-    if (component > lbl_80650A20)
-        component = *(float*)(state + 0x70);
-    *(float*)(state + 0x64) = component;
-    component = *(float*)(state + 0x68);
-    if (component > lbl_80650A20)
-        component = *(float*)(state + 0x74);
-    *(float*)(state + 0x68) = component;
-
-    fn_80198154(self_local + 0x10, locals.vectors,
-                (self_local[1] & 0x7F) << 1, 0,
-                (Vec3*)(state + 0x60));
-
-    if ((*(u16*)(state + 0x40) & 2) != 0 ||
-        ((state[5] & 1) == 0 &&
-         (int)generation >= (int)*(u16*)(self_local + 0xC))) {
-        *(u16*)(self_local + 0x22) = 8;
+    fn_80211A48((Vec3 *) (state + 0x60), (Vec3 *) (state + 0x6C), (Vec3 *) (state + 0x60));
+    component = *((float *) (state + 0x60));
+    if (component > lbl_80650A20) {
+        component = *((float *) (state + 0x6C));
+    }
+    state_bytes = state;
+    *((float *) (state_bytes + 0x60)) = component;
+    component = *((float *) (state_bytes + 0x64));
+    if (component > lbl_80650A20) {
+        component = *((float *) (state_bytes + 0x70));
+    }
+    *((float *) (state_bytes + 0x64)) = component;
+    component = *((float *) (state_bytes + 0x68));
+    if (component > lbl_80650A20) {
+        component = *((float *) (state_bytes + 0x74));
+    }
+    *((float *) (state_bytes + 0x68)) = component;
+    fn_80198154(self_local + 0x10, locals.vectors, (self_local[1] & 0x7F) << 1, 0, (Vec3 *) (state_bytes + 0x60));
+    if ((((*((u16 *) (state_bytes + 0x40))) & 2) != 0) || (((state_bytes[5] & 1) == 0) && (((int) generation) >= ((int) (*((u16 *) (self_local + 0xC))))))) {
+        *((u16 *) (self_local + 0x22)) = 8;
     }
     return 0;
 }

--- a/src/game/game_fn_80187A4C.c
+++ b/src/game/game_fn_80187A4C.c
@@ -31,6 +31,7 @@ void fn_80187A4C(u8* self, void* arg1, void* arg2, u8* desc)
 {
     SixBytes setup;
     u8* entry;
+    int value;
 
     setup.word = lbl_80651D60;
     setup.half = lbl_80651D64;
@@ -47,9 +48,13 @@ void fn_80187A4C(u8* self, void* arg1, void* arg2, u8* desc)
     memset(self + 0x24, 0, 0x10);
 
     fn_80180554(entry, arg1, arg2, &setup, 0, 0);
-    fn_801805E0(entry + 0x20, 4,
-                *(int*)(desc + 0x20) != 0 ? desc[1] >> 1 : desc[1], 0,
-                lbl_802FC5BC, lbl_80650A54);
+    if (*(int*)(desc + 0x20) != 0) {
+        value = (u8)(desc[1] >> 1);
+    } else {
+        value = desc[1];
+    }
+    fn_801805E0(entry + 0x20, 4, value, 0, lbl_802FC5BC,
+                lbl_80650A54);
     fn_8018E230(entry, entry + 0x2B, 1, 0, (s8)desc[0x24], desc[0x25]);
     fn_8018CB70(*(void**)(self + 0x54), 1, *(u16*)(lbl_80607130 + 2));
     fn_8018C540(*(void**)(self + 0x58), lbl_802FC5BC, 1, 4,

--- a/src/game/game_fn_8018B058.c
+++ b/src/game/game_fn_8018B058.c
@@ -31,8 +31,8 @@ void fn_8018B058(u8* object)
     u8* color_data;
     u8* color;
     int saved;
-    register u16 index;
-    register int i;
+    int index;
+    int i;
 
     offset = *(u16*)(lbl_80607130 + 2);
     vertex_size = *(u16*)(lbl_80607130 + 0xA);

--- a/src/game/game_fn_8018C6EC.c
+++ b/src/game/game_fn_8018C6EC.c
@@ -7,18 +7,18 @@ extern void* memcpy(void*, const void*, unsigned int);
 
 void fn_8018C6EC(u8* dest, const u8* color, u8 repeats, int run_length, u16 offset)
 {
-    u8* start = dest;
     int i;
+    int j;
+    u8* cursor = dest;
 
     for (i = 0; i < repeats; i++) {
-        int j;
         for (j = 0; j < run_length; j++) {
-            dest[0] = color[0];
-            dest[1] = color[1];
-            dest[2] = color[2] - (fn_800FBFB0() & 0x1F);
-            dest[3] = color[3];
-            dest += 4;
+            cursor[0] = color[0];
+            cursor[1] = color[1];
+            cursor[2] = color[2] - (fn_800FBFB0() & 0x1F);
+            cursor[3] = color[3];
+            cursor += 4;
         }
     }
-    memcpy(start + offset * 4, start, lbl_80607120[6]);
+    memcpy(dest + offset * 4, dest, lbl_80607120[6]);
 }

--- a/src/game/game_fn_8018D020.c
+++ b/src/game/game_fn_8018D020.c
@@ -8,10 +8,10 @@ void fn_8018D020(s16* out, float x, float y, float z, float w, float t)
     out[3] = z;
     out[4] = y;
     out[5] = t;
-    out[6] = w;
-    out[7] = t;
-    out[8] = x;
-    out[9] = w;
+    out[6] = z;
+    out[7] = w;
+    out[8] = t;
+    out[9] = x;
     out[10] = w;
     out[11] = t;
 }

--- a/src/game/game_fn_8018E504.c
+++ b/src/game/game_fn_8018E504.c
@@ -1,6 +1,8 @@
 typedef unsigned char u8;
 typedef signed char s8;
 
+#define SUB_CLAMP0(a, b) ((a) - (b) > 0 ? (a) - (b) : 0)
+
 extern void fn_8018E8B8(u8*, u8, int);
 
 u8 fn_8018E504(u8* state, u8* object)
@@ -59,16 +61,8 @@ u8 fn_8018E504(u8* state, u8* object)
                 state[0] = 0;
             } else {
                 if ((s8)state[5] > 0) {
-                    int amount = (s8)state[5];
-                    if (amount < 0) {
-                        amount = -amount;
-                    }
-                    state[2] = state[2] - amount > 0 ? state[2] - amount : 0;
-                    amount = (s8)state[5];
-                    if (amount < 0) {
-                        amount = -amount;
-                    }
-                    state[3] = state[3] - amount > 0 ? state[3] - amount : 0;
+                    state[2] = SUB_CLAMP0(state[2], __abs(*(s8*)(state + 5)));
+                    state[3] = SUB_CLAMP0(state[3], __abs(*(s8*)(state + 5)));
                     state[1] = state[3];
                 } else {
                     state[1] = state[2];

--- a/src/game/game_fn_80196B10.c
+++ b/src/game/game_fn_80196B10.c
@@ -48,7 +48,8 @@ int fn_80196B10(u8* object)
     }
 
     if ((tick & object[0x8e]) == 0) {
-        fn_80198420(object + 0x10, *(void**)(object + 0x4c), object[1], output,
+        int entry_count = object[1];
+        fn_80198420(object + 0x10, *(void**)(object + 0x4c), entry_count, output,
                      object[0x8c]);
         if ((tick & 1) == 0) {
             object[0x8c] += object[0xa1];

--- a/src/game/game_fn_8019BDE8.c
+++ b/src/game/game_fn_8019BDE8.c
@@ -26,12 +26,13 @@ void fn_8019BDE8(u8* object, void* first, void* second, u8* config)
 {
     u8 count;
     u8* entry;
+    s16 mode;
     int i;
+    u8 base[8];
     struct {
         u32 word;
         u16 half;
     } setup;
-    u8 base[8];
     u8 current[8];
     u8 work[8];
 
@@ -61,7 +62,8 @@ void fn_8019BDE8(u8* object, void* first, void* second, u8* config)
         memcpy(current, base, 6);
         memcpy(work, first, 6);
         *(s16*)(current + 4) = -32;
-        fn_8018EFB0(work, *(u16*)(config + 0x16), 0);
+        mode = *(u16*)(config + 0x16);
+        fn_8018EFB0(work, mode, 0);
         fn_8018EFB0(work, *(u16*)(config + 0x16), 1);
         fn_80180554(entry, work, current, &setup,
                     *(u16*)(config + 8), 1);

--- a/src/game/game_fn_8019D030.c
+++ b/src/game/game_fn_8019D030.c
@@ -37,6 +37,8 @@ void fn_8019D030(u8* object, void* first, void* second, u8* config)
 {
     SixBytes setup;
     int x_negative;
+    int bits;
+    int value;
     int y_negative;
     int z_negative;
     void* texture;
@@ -66,7 +68,8 @@ void fn_8019D030(u8* object, void* first, void* second, u8* config)
     fn_8017E958(entry + 0xA, object + 0x10, *(s16*)(config + 0x16),
                 lbl_80650C3C);
     texture = lbl_802FC5BC + 0xC;
-    fn_801805E0(entry + 0x20, 4, config[1], 0, lbl_80650C44, texture);
+    value = config[1];
+    fn_801805E0(entry + 0x20, 4, value, 0, lbl_80650C44, texture);
     fn_80180518(object + 0x24, 0, 1);
     fn_8018E230(entry, entry + 0x2B, 1, 0, (s8)config[0x14], config[0x15]);
 
@@ -78,10 +81,10 @@ void fn_8019D030(u8* object, void* first, void* second, u8* config)
                 config[0x15]);
 
     entry += 0x70;
-    x_negative = fn_800FBFB0();
-    y_negative = x_negative & 2;
-    z_negative = x_negative & 4;
-    x_negative &= 1;
+    bits = fn_800FBFB0();
+    x_negative = bits & 1;
+    y_negative = bits & 2;
+    z_negative = bits & 4;
     i = 2;
     for (; i < 5; i++, entry += 0x38) {
         int random;

--- a/src/game/game_fn_801A80FC.c
+++ b/src/game/game_fn_801A80FC.c
@@ -6,8 +6,8 @@ extern void* memcpy(void*, const void*, unsigned long);
 
 u32 fn_801A80FC(u8* destination, u16 count, u8* input)
 {
-    u16 limit = count;
     u8* source = input;
+    int limit = count;
     u32 size = 0;
     int index = 0;
 

--- a/src/game/game_fn_801A81FC.c
+++ b/src/game/game_fn_801A81FC.c
@@ -6,8 +6,8 @@ extern void* memcpy(void*, const void*, unsigned long);
 
 u32 fn_801A81FC(u8* source, u16 count, u8* output)
 {
-    u16 limit = count;
     u8* record = output;
+    int limit = count;
     u32 size = 0;
     int index = 0;
 

--- a/src/game/game_fn_801A8C60.c
+++ b/src/game/game_fn_801A8C60.c
@@ -4,19 +4,21 @@ typedef unsigned char u8;
 
 void fn_801A8C60(s32 upper, s32 lower, u8* value, s16* delta)
 {
+    s32 current = *value;
     s32 step = *delta;
-    u8 current = *value;
 
     if (step > 0) {
         if (current + step < upper) {
-            *value = current + step;
+            current += step;
+            *value = current;
         } else {
             *value = upper;
             *delta = -*delta;
         }
     } else if (step < 0) {
         if (current + step > lower) {
-            *value = current + step;
+            current += step;
+            *value = current;
         } else {
             *value = lower;
             *delta = -*delta;

--- a/src/game/game_fn_801B3A2C.c
+++ b/src/game/game_fn_801B3A2C.c
@@ -40,7 +40,7 @@ static inline u32 resolve_handle(u32 value)
     return -1;
 }
 
-void fn_801B3A2C(u32 handle, u16 value)
+u8* fn_801B3A2C(u32 handle, u16 value)
 {
     u8* base = (u8*)lbl_8060C020;
     u32 id = resolve_handle(handle);
@@ -57,4 +57,5 @@ void fn_801B3A2C(u32 handle, u16 value)
         entry[0x22DA] |= 0x20;
         *(u16*)(entry + 0x22D8) = value;
     }
+    return entry;
 }

--- a/src/game/game_fn_801B7DC8.c
+++ b/src/game/game_fn_801B7DC8.c
@@ -1,38 +1,39 @@
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
-typedef int s32;
+typedef short s16;
 
-typedef struct SequenceInfo {
-    u8 pad0[2];
-    u16 flags;
-    u8 arg2;
-    u8 pitch;
+typedef struct FXTab {
+    u16 id;
+    u16 macro;
+    u8 max_voices;
+    u8 priority;
+    u8 volume;
+    u8 panning;
     u8 key;
-    u8 velocity;
-    u8 arg3;
-    u8 arg11;
-} SequenceInfo;
+    u8 volume_group;
+} FXTab;
 
-extern SequenceInfo* fn_801BD1EC(u32);
-extern s32 fn_801B64D0(u32, s32, u32, u32, u32, u32, u8, u8, u8, u16,
-                       u16, u8, short, u8, u32);
+extern FXTab* fn_801BD1EC(u16);
+extern u32 fn_801B64D0(u16, u8, u8, u8, u8, u8, u8, u8, u8, u16, u16,
+                       u8, s16, u8, u32);
 
-s32 fn_801B7DC8(u32 sequence, u32 key, u32 velocity, u8 arg13, u32 arg14)
+u32 fn_801B7DC8(u16 effect_id, u8 volume, u8 panning, u8 studio, u32 itd)
 {
-    s32 result = -1;
-    SequenceInfo* info = fn_801BD1EC(sequence);
+    u32 voice_id = -1;
+    FXTab* effect = fn_801BD1EC(effect_id);
 
-    if (info != 0) {
-        if ((u8)key == 0xFF) {
-            key = info->key;
+    if (effect != 0) {
+        if (volume == 0xFF) {
+            volume = effect->volume;
         }
-        if ((u8)velocity == 0xFF) {
-            velocity = info->velocity;
+        if (panning == 0xFF) {
+            panning = effect->panning;
         }
-        result = fn_801B64D0(info->flags, info->pitch, info->arg2,
-                             info->arg3 | 0x80, key, velocity, 0xFF, 0xFF,
-                             0, 0, 0xFF, info->arg11, 0, arg13, arg14);
+        voice_id = fn_801B64D0(effect->macro, effect->priority,
+                               effect->max_voices, effect->key | 0x80,
+                               volume, panning, 0xFF, 0xFF, 0, 0, 0xFF,
+                               effect->volume_group, 0, studio, itd);
     }
-    return result;
+    return voice_id;
 }

--- a/src/game/game_fn_801B7E84.c
+++ b/src/game/game_fn_801B7E84.c
@@ -4,24 +4,24 @@ typedef unsigned long long u64;
 
 extern u8* lbl_8064D3D0;
 extern u32 fn_801C14D0(u32);
-extern void fn_801CA7C0();
+extern void fn_801CA7C0(u8, u8, u8, u8);
 
-u32 fn_801B7E84(u32 handle, u32 arg1, u32 arg2)
+u32 fn_801B7E84(u32 handle, u8 control, u8 value)
 {
     u32 result = 0;
     u32 voice = fn_801C14D0(handle);
 
     while (voice != 0xFFFFFFFF) {
-        u32 index = (u8)voice;
+        u32 index = voice & 0xFF;
         u32 offset = index * 0x404;
 
         if (voice == *(u32*)(lbl_8064D3D0 + offset + 0xF4)) {
             u8* state = lbl_8064D3D0 + offset;
 
             if ((*(u64*)(state + 0x114) & 2) != 0) {
-                fn_801CA7C0(arg1, index, state[0x20B], arg2);
+                fn_801CA7C0(control, index, state[0x20B], value);
             } else {
-                fn_801CA7C0(arg1, index, state[0x122], arg2);
+                fn_801CA7C0(control, index, state[0x122], value);
             }
 
             result = 1;

--- a/src/game/game_fn_801B7F6C.c
+++ b/src/game/game_fn_801B7F6C.c
@@ -1,27 +1,28 @@
 typedef unsigned char u8;
+typedef unsigned short u16;
 typedef unsigned int u32;
 typedef unsigned long long u64;
 
 extern u8* lbl_8064D3D0;
 extern u32 fn_801C14D0(u32);
-extern void fn_801CAD90();
+extern void fn_801CAD90(u8, u8, u8, u16);
 
-u32 fn_801B7F6C(u32 handle, u32 arg1, u32 arg2)
+u32 fn_801B7F6C(u32 handle, u8 control, u16 value)
 {
     u32 result = 0;
     u32 voice = fn_801C14D0(handle);
 
     while (voice != 0xFFFFFFFF) {
-        u32 index = (u8)voice;
+        u32 index = voice & 0xFF;
         u32 offset = index * 0x404;
 
         if (voice == *(u32*)(lbl_8064D3D0 + offset + 0xF4)) {
             u8* state = lbl_8064D3D0 + offset;
 
             if ((*(u64*)(state + 0x114) & 2) != 0) {
-                fn_801CAD90(arg1, index, state[0x20B], arg2);
+                fn_801CAD90(control, index, state[0x20B], value);
             } else {
-                fn_801CAD90(arg1, index, state[0x122], arg2);
+                fn_801CAD90(control, index, state[0x122], value);
             }
 
             result = 1;

--- a/src/game/game_fn_801B8C28.c
+++ b/src/game/game_fn_801B8C28.c
@@ -2,7 +2,7 @@ typedef unsigned int u32;
 
 extern void fn_801CE2B8(void);
 extern void fn_801CE280(void);
-extern void fn_801B3A2C(u32, u32);
+extern unsigned char* fn_801B3A2C(u32, u32);
 
 void fn_801B8C28(u32 handle, u32 value)
 {

--- a/src/game/game_fn_801B8D88.c
+++ b/src/game/game_fn_801B8D88.c
@@ -1,13 +1,16 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+
 extern void fn_801CE2B8(void);
 extern void fn_801CE280(void);
-extern int fn_801B7E84(int, int, int);
+extern u32 fn_801B7E84(u32, u8, u8);
 
-int fn_801B8D88(int arg0, int arg1, int arg2)
+u32 fn_801B8D88(u32 voice_id, u8 control, u8 value)
 {
-    int result;
+    u32 result;
 
     fn_801CE2B8();
-    result = fn_801B7E84(arg0, arg1, arg2);
+    result = fn_801B7E84(voice_id, control, value);
     fn_801CE280();
     return result;
 }

--- a/src/game/game_fn_801B8DE8.c
+++ b/src/game/game_fn_801B8DE8.c
@@ -1,13 +1,17 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
 extern void fn_801CE2B8(void);
 extern void fn_801CE280(void);
-extern int fn_801B7F6C(int, int, int);
+extern u32 fn_801B7F6C(u32, u8, u16);
 
-int fn_801B8DE8(int arg0, int arg1, int arg2)
+u32 fn_801B8DE8(u32 voice_id, u8 control, u16 value)
 {
-    int result;
+    u32 result;
 
     fn_801CE2B8();
-    result = fn_801B7F6C(arg0, arg1, arg2);
+    result = fn_801B7F6C(voice_id, control, value);
     fn_801CE280();
     return result;
 }

--- a/src/game/game_fn_801B8E88.c
+++ b/src/game/game_fn_801B8E88.c
@@ -1,14 +1,19 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
 extern void fn_801CE2B8(void);
 extern void fn_801CE280(void);
-extern int fn_801B7DC8();
-extern unsigned char lbl_8061A4F4[];
+extern u32 fn_801B7DC8(u16, u8, u8, u8, u32);
+extern u8 lbl_8061A4F4[];
 
-int fn_801B8E88(int arg0, int arg1, int arg2, int arg3)
+u32 fn_801B8E88(u16 effect_id, u8 volume, u8 panning, u8 studio)
 {
-    int result;
+    u32 voice_id;
 
     fn_801CE2B8();
-    result = fn_801B7DC8(arg0, arg1, arg2, arg3, lbl_8061A4F4[(unsigned char)arg3 * 2 + 1]);
+    voice_id = fn_801B7DC8(effect_id, volume, panning, studio,
+                           lbl_8061A4F4[studio * 2 + 1]);
     fn_801CE280();
-    return result;
+    return voice_id;
 }

--- a/src/game/game_fn_801B8F84.c
+++ b/src/game/game_fn_801B8F84.c
@@ -1,10 +1,14 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
 extern void fn_801CE2B8(void);
 extern void fn_801CE280(void);
-extern void fn_801B8164();
+extern void fn_801B8164(u8, u16, u8, u8, u32);
 
-void fn_801B8F84(int arg0, int arg1, int arg2)
+void fn_801B8F84(u8 volume, u16 time, u8 volume_group)
 {
     fn_801CE2B8();
-    fn_801B8164(arg0, arg1, arg2, 0, -1);
+    fn_801B8164(volume, time, volume_group, 0, -1);
     fn_801CE280();
 }

--- a/src/game/game_fn_801B8FE4.c
+++ b/src/game/game_fn_801B8FE4.c
@@ -1,17 +1,19 @@
 typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
 
 extern void fn_801CE2B8(void);
 extern void fn_801CE280(void);
-extern void fn_801B8164(int, int, int, int, int);
+extern void fn_801B8164(u8, u16, u8, u8, u32);
 
-void fn_801B8FE4(int arg0, int arg1, u8 arg2, u8 arg3)
+void fn_801B8FE4(u8 volume, u16 time, u8 music, u8 effects)
 {
     fn_801CE2B8();
-    if (arg2) {
-        fn_801B8164(arg0, arg1, 0x15, 0, -1);
+    if (music) {
+        fn_801B8164(volume, time, 0x15, 0, -1);
     }
-    if (arg3) {
-        fn_801B8164(arg0, arg1, 0x16, 0, -1);
+    if (effects) {
+        fn_801B8164(volume, time, 0x16, 0, -1);
     }
     fn_801CE280();
 }

--- a/src/game/game_fn_801B9220.c
+++ b/src/game/game_fn_801B9220.c
@@ -19,7 +19,7 @@ void fn_801B9220(int arg0)
     int offset;
     u32 i;
 
-    for (offset = 0, i = 0; i < lbl_80619C20[0x210]; offset += 0x404, i++) {
+    for (i = 0, offset = 0; i < lbl_80619C20[0x210]; offset += 0x404, i++) {
         u8* entry = lbl_8064D3D0 + offset;
         if ((u8)arg0 == entry[0x11F]) {
             if (*(u32*)(entry + 0xF4) != (u32)-1) {
@@ -32,8 +32,9 @@ void fn_801B9220(int arg0)
 
     fn_801CE2B8();
     {
+        u32 word_offset;
         u8 index = (u8)arg0;
-        u32 word_offset = (u32)index * 4;
+        word_offset = (u32)index * 4;
         *(u32*)((u8*)lbl_8061A494 + word_offset) = 0;
         *(u32*)((u8*)lbl_8061A4D4 + word_offset) = 0;
         (&lbl_8064D3BC)[index] = 0xFF;

--- a/src/game/game_fn_801C0ED8.c
+++ b/src/game/game_fn_801C0ED8.c
@@ -27,9 +27,9 @@ void fn_801C0ED8(void)
 {
     u32 i;
 
-    lbl_8064D448 = 0;
     lbl_8064D43C = 0;
     lbl_8064D440 = 0;
+    lbl_8064D448 = 0;
 
     for (i = 0; i < lbl_80619C20.voice_count_210; i++) {
         lbl_8064D3D0[i].value_034 = 0;

--- a/src/game/game_fn_801C29BC.c
+++ b/src/game/game_fn_801C29BC.c
@@ -22,11 +22,11 @@ float fn_801C29BC(u32 target, u32 value)
         value = 0x40005622;
     }
     high = value >> 24;
-    if (target != high) {
-        if (high < target) {
-            amount = lbl_802525A8[target - high];
+    if ((u8)target != high) {
+        if (high < (u8)target) {
+            amount = lbl_802525A8[(u8)target - high];
         } else {
-            amount = lbl_802527A8[high - target];
+            amount = lbl_802527A8[high - (u8)target];
         }
         amount = (value & 0xFFFFFF) * amount;
     } else {

--- a/src/game/game_fn_801C2B00.c
+++ b/src/game/game_fn_801C2B00.c
@@ -92,7 +92,8 @@ int fn_801C2B00(Envelope* envelope)
             if (envelope->level != 0) {
                 envelope->state = 3;
                 envelope->secondary = (u32)envelope->level << 16;
-                index = 193 - ((int)(envelope->secondary + 0x8000) >> 16);
+                index = envelope->secondary + 0x8000;
+                index = 193 - ((int)index >> 16);
                 if ((int)index < 0) {
                     index = 0;
                 }

--- a/src/game/game_fn_801C2F34.c
+++ b/src/game/game_fn_801C2F34.c
@@ -50,7 +50,8 @@ int fn_801C2F34(Envelope* envelope, u16* level, u16* delta)
                 envelope->value += envelope->step;
             } else {
                 envelope->secondary += envelope->step;
-                change = 193 - ((envelope->secondary + 0x8000) >> 16);
+                change = envelope->secondary + 0x8000;
+                change = 193 - (change >> 16);
                 if (change < 0) {
                     change = 0;
                 }

--- a/src/game/game_fn_801C36FC.c
+++ b/src/game/game_fn_801C36FC.c
@@ -29,12 +29,14 @@ extern void fn_801C350C(StreamRequest*, u32);
 
 void fn_801C36FC(void)
 {
-    SoundState* sound = &lbl_80627D60;
-    u8* cursor = (u8*)sound;
+    SoundState* sound;
+    u8* cursor;
     u32 i;
-    u32 unused[1];
-    if (sound->callback == 0) return;
-    for (i = 0; i < 64; i++, cursor++) {
+    u32 count = sizeof(lbl_80627D60.map);
+    if (lbl_80627D60.callback == 0) return;
+    sound = &lbl_80627D60;
+    cursor = (u8*)sound;
+    for (i = 0; i < count; i++, cursor++) {
         u32 pos;
         StreamRequest* req;
         u32 target;

--- a/src/game/game_fn_801C8224.c
+++ b/src/game/game_fn_801C8224.c
@@ -73,8 +73,6 @@ void fn_801C8224(void)
     float distance;
     float best_distance;
     float delta[3];
-    double threshold;
-    float scale;
 
     fn_801C8160();
 
@@ -87,8 +85,6 @@ void fn_801C8224(void)
 
     if (count != 0) {
         target = lbl_8064D4C4;
-        scale = lbl_80650FC4;
-        threshold = lbl_80650FC8;
         while (target != 0) {
             if (target->channel == 0xFF) {
                 sample = lbl_8064D4C0;
@@ -160,7 +156,7 @@ void fn_801C8224(void)
 
                 target->mean_square_distance = distance;
                 target->fade = found ? 0x007F0000 : 0;
-                if (scale * (float)target->fade >= threshold) {
+                if (target->fade * 1.2014794e-07f >= 0.5) {
                     fn_801B9170(target->channel, 1, 0);
                 } else {
                     fn_801B9170(target->channel, 0, 0);
@@ -175,7 +171,7 @@ void fn_801C8224(void)
                         target->fade = 0x007F0000;
                         target->owner &= 0x7FFFFFFF;
                     }
-                    if (scale * (float)target->fade >= threshold) {
+                    if (target->fade * 1.2014794e-07f >= 0.5) {
                         fn_801B9170(target->channel, 1, 0);
                     } else {
                         fn_801B9170(target->channel, 0, 0);
@@ -187,7 +183,7 @@ void fn_801C8224(void)
                         target->fade = 0;
                         target->owner &= 0xBFFFFFFF;
                     }
-                    if (scale * (float)target->fade >= threshold) {
+                    if (target->fade * 1.2014794e-07f >= 0.5) {
                         fn_801B9170(target->channel, 1, 0);
                     } else {
                         fn_801B9170(target->channel, 0, 0);

--- a/src/game/game_fn_801CA288.c
+++ b/src/game/game_fn_801CA288.c
@@ -1,67 +1,70 @@
 typedef unsigned char u8;
+typedef unsigned short u16;
 typedef unsigned int u32;
 
-typedef struct AudioConfig {
+typedef struct SynthInfo {
     char pad00[0x210];
-    u8 voices;
-    u8 field211;
-    u8 field212;
-    u8 channels;
-} AudioConfig;
+    u8 voice_count;
+    u8 max_music;
+    u8 max_sfx;
+    u8 studio_count;
+} SynthInfo;
 
-typedef struct InitConfig {
-    u32 value;
-    char pad04[0xC];
-} InitConfig;
-
-extern AudioConfig lbl_80619C20;
+extern SynthInfo lbl_80619C20;
 extern u8 lbl_8064D3A0;
 extern u8 lbl_8064D3D8;
 
-extern int fn_801CC5D4(InitConfig*, u8, u8, u32);
+extern int fn_801CC5D4(u32*, u16, u16, u32);
 extern void fn_801C38C0(void);
 extern void fn_801BD294(int, u32);
 extern void fn_801B58F0(void);
-extern void fn_801B86C0(int, u8);
+extern void fn_801B86C0(u32, u32);
 extern void fn_801B9350(void);
 extern void fn_801C3158(void);
 extern void fn_801CA240(u32);
 
-int fn_801CA288(u8 voices, u8 field211, u8 field212, u8 channels, u32 flags,
-                u32 value)
+static inline int DoInit(u32 mix_frequency, u32 aram_size, u32 voice_count,
+                         u32 flags)
 {
-    u8 saved_voices;
-    InitConfig init;
-    int result;
+    int result = 0;
 
+    fn_801C38C0();
+    fn_801BD294(0, aram_size);
+    fn_801B58F0();
+    lbl_8064D3D8 = 0;
+    fn_801B86C0(mix_frequency, voice_count);
+    fn_801B9350();
+    fn_801C3158();
+    fn_801CA240(flags);
+    lbl_8064D3A0 = 1;
+    return result;
+}
+
+int fn_801CA288(u8 voices, u8 music, u8 sfx, u8 studios, u32 flags,
+                u32 aram_size)
+{
+    int result;
+    u32 frequency;
+
+    result = 0;
     lbl_8064D3A0 = 0;
     if (voices <= 0x40) {
-        lbl_80619C20.voices = voices;
+        lbl_80619C20.voice_count = voices;
     } else {
-        lbl_80619C20.voices = 0x40;
+        lbl_80619C20.voice_count = 0x40;
     }
-    if (channels <= 8) {
-        lbl_80619C20.channels = channels;
+    if (studios <= 8) {
+        lbl_80619C20.studio_count = studios;
     } else {
-        lbl_80619C20.channels = 8;
+        lbl_80619C20.studio_count = 8;
     }
-    lbl_80619C20.field211 = field211;
-    lbl_80619C20.field212 = field212;
-    init.value = 0x7D00;
-    result = fn_801CC5D4(&init, lbl_80619C20.voices,
-                         lbl_80619C20.channels, flags);
+    lbl_80619C20.max_music = music;
+    lbl_80619C20.max_sfx = sfx;
+    frequency = 0x7D00;
+    result = fn_801CC5D4(&frequency, lbl_80619C20.voice_count,
+                         lbl_80619C20.studio_count, flags);
     if (result == 0) {
-        saved_voices = lbl_80619C20.voices;
-        fn_801C38C0();
-        fn_801BD294(0, value);
-        fn_801B58F0();
-        lbl_8064D3D8 = 0;
-        fn_801B86C0(0x7D00, saved_voices);
-        fn_801B9350();
-        fn_801C3158();
-        fn_801CA240(flags);
-        lbl_8064D3A0 = 1;
-        result = 0;
+        result = DoInit(0x7D00, aram_size, lbl_80619C20.voice_count, flags);
     }
     return result;
 }

--- a/src/game/game_fn_801CAD90.c
+++ b/src/game/game_fn_801CAD90.c
@@ -2,22 +2,22 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-extern void fn_801CA7C0(int, int, int, int);
+extern void fn_801CA7C0(u8, u8, u8, u8);
 
-void fn_801CAD90(int control, int channel, int layer, u16 value)
+void fn_801CAD90(u8 control, u8 channel, u8 set, u16 value)
 {
-    if ((u8)channel != 0xFF) {
-        if ((u8)control < 0x40) {
-            fn_801CA7C0((u8)control & 0x1F, channel, layer, (value >> 7) & 0xFF);
-            fn_801CA7C0(((u8)control & 0x1F) + 0x20, channel, layer, value & 0x7F);
-        } else if ((u8)(control - 0x80) <= 1) {
-            fn_801CA7C0((u8)control & 0xFE, channel, layer, (value >> 7) & 0xFF);
-            fn_801CA7C0(((u8)control & 0xFE) + 1, channel, layer, value & 0x7F);
-        } else if ((u8)(control - 0x84) <= 1) {
-            fn_801CA7C0((u8)control & 0xFE, channel, layer, (value >> 7) & 0xFF);
-            fn_801CA7C0(((u8)control & 0xFE) + 1, channel, layer, value & 0x7F);
+    if (channel != 0xFF) {
+        if (control < 0x40) {
+            fn_801CA7C0(control & 0x1F, channel, set, (value >> 7) & 0xFF);
+            fn_801CA7C0((control & 0x1F) + 0x20, channel, set, value & 0x7F);
+        } else if (control == 0x80 || control == 0x81) {
+            fn_801CA7C0(control & 0xFE, channel, set, (value >> 7) & 0xFF);
+            fn_801CA7C0((control & 0xFE) + 1, channel, set, value & 0x7F);
+        } else if (control == 0x84 || control == 0x85) {
+            fn_801CA7C0(control & 0xFE, channel, set, (value >> 7) & 0xFF);
+            fn_801CA7C0((control & 0xFE) + 1, channel, set, value & 0x7F);
         } else {
-            fn_801CA7C0(control, channel, layer, (value >> 7) & 0xFF);
+            fn_801CA7C0(control, channel, set, (value >> 7) & 0xFF);
         }
     }
 }

--- a/src/game/game_fn_801CAEB8.c
+++ b/src/game/game_fn_801CAEB8.c
@@ -6,20 +6,20 @@ extern u8 lbl_8023B3D0[];
 extern u8 lbl_8062A2F0[];
 extern u8 lbl_8062E5F0[];
 extern void* memcpy(void*, const void*, u32);
-extern void fn_801CB470(int, int, int);
+extern void fn_801CB470(u8, u8, u8);
 
-void fn_801CAEB8(int channel, u32 layer, u32 copy_all)
+void fn_801CAEB8(u8 channel, u8 set, u32 cold_reset)
 {
-    u8* source = copy_all != 0 ? lbl_8023B348 : lbl_8023B3D0;
+    u8* source = cold_reset != 0 ? lbl_8023B348 : lbl_8023B3D0;
     u8* destination;
 
-    if ((u8)layer != 0xFF) {
-        destination = lbl_8062A2F0 + (u8)layer * 2144 + (u8)channel * 134;
+    if (set != 0xFF) {
+        destination = lbl_8062A2F0 + set * 2144 + channel * 134;
     } else {
-        destination = lbl_8062E5F0 + (u8)channel * 134;
+        destination = lbl_8062E5F0 + channel * 134;
     }
 
-    if (copy_all != 0) {
+    if (cold_reset != 0) {
         memcpy(destination, source, 134);
     } else {
         u32 i;
@@ -30,5 +30,5 @@ void fn_801CAEB8(int channel, u32 layer, u32 copy_all)
         }
     }
 
-    fn_801CB470(channel, layer, 0xFF);
+    fn_801CB470(channel, set, 0xFF);
 }

--- a/src/game/game_fn_801CC13C.c
+++ b/src/game/game_fn_801CC13C.c
@@ -1,7 +1,6 @@
 typedef unsigned char u8;
-typedef unsigned int u32;
 
-u32 fn_801CC13C(u32 value)
+u8 fn_801CC13C(u8 value)
 {
     switch ((u8)value) {
     case 0x80:

--- a/src/game/game_fn_801CC24C.c
+++ b/src/game/game_fn_801CC24C.c
@@ -1,6 +1,6 @@
 typedef unsigned char u8;
 typedef signed short s16;
-typedef unsigned int u32;
+typedef unsigned short u16;
 
 typedef struct State {
     u8 pad[0x121];
@@ -8,14 +8,14 @@ typedef struct State {
     u8 layer;
 } State;
 
-extern u32 fn_801CC13C(u32);
-extern void fn_801CAD90(u32, u8, u8, s16);
+extern u8 fn_801CC13C(u8);
+extern void fn_801CAD90(u8, u8, u8, u16);
 
-void fn_801CC24C(State* state, u32 control, s16 value)
+void fn_801CC24C(State* state, u8 control, s16 value)
 {
     value = value < 0 ? 0 : value > 0x3FFF ? 0x3FFF : value;
 
-    switch ((u8)fn_801CC13C(control)) {
+    switch (fn_801CC13C(control)) {
     default:
         if (state->channel != 0xFF) {
             fn_801CAD90(control, state->channel, state->layer, value);


### PR DESCRIPTION
## Progress

This raises matched code from 32.82% to 33.94%: 4,812 to 4,890 of 8,216 functions and 5,045 to 5,124 of 6,215 objects. It adds 25,752 matched code bytes (755,016 to 780,768 of 2,300,692).

## Current behavior

These 79 functions (80 function bodies, since `fn_80008134` shares an object with `fn_80008014`) did not compile to the retail instruction streams or did not carry retail's relocation names. The causes fall into six groups: wrong function interfaces copied from callers or callees, wrong structure layouts and data models, declaration order and local lifetime, expression and control-flow shape, compiler-private literals that retail exposes as named `.sdata2` symbols, and per-object compiler settings.

## New behavior

All 80 function bodies match retail exactly in code size, instructions, and relocation names and addresses. Two files also gain the retail `.data` alignment and split-constant ownership through narrow configured post-compile rules.

## How

### Function interfaces proven from matching callers and callees

- `fn_8000E96C`: `fn_8013F3C0` takes four arguments, as its matching definition shows; the two extra float arguments created artificial FPR live ranges.
- `fn_800A2D1C`, `fn_800A3C4C`, `fn_800F0CC4`, `fn_80164A64`, `fn_8017AE90`, `fn_80182984`, `fn_80127178`: prototypes corrected to the parameter counts, widths, and signedness proven by already-matching callers or callees (`fn_800A3C4C` itself gains its two forwarded mode parameters; `fn_8017BA54` receives one `u64`; `fn_800F3C98` receives the cache range).
- MusyX wrappers `fn_801B7DC8`, `fn_801B7E84`, `fn_801B7F6C`, `fn_801B8D88`, `fn_801B8DE8`, `fn_801B8E88`, `fn_801B8F84`, `fn_801B8FE4`, `fn_801CAD90`, `fn_801CAEB8`, `fn_801CC24C`: the public MusyX parameter widths (`u16` effect id, `u8` volume/panning/studio/control/channel, `u32` voice id, `u16` 14-bit value) remove the oversized parameter-home frames.
- `fn_801397F8` returns the selected buffer pointer, which its already-matching caller `fn_801388F8` stores; `fn_80139464` and `fn_801392A8` declare it that way.
- `fn_801301B0` returns the previous flags byte and `fn_801B3A2C` returns the entry it updated; retail keeps each value live in `r3` to the return. Their callers' declarations are updated and remain exact.
- `fn_8012E42C` takes its `Vec3` by value; MWCC passes the struct through a pointer to the caller's copy, which is the copy retail makes in `fn_8012E200`. The callee stays exact.
- `fn_80187A4C`: the optionally halved descriptor byte is merged in an `int` and narrowed explicitly before the proven `u8` parameter of `fn_801805E0`.

### Structure layouts and data models

- `fn_801493D4`: the query-result tail is 20 bytes, the same 40-byte layout `game_fn_801534D8.c` already uses.
- `fn_8014B7B0`: `fn_80143C28` writes a 24-byte result and two pointers; modeling those outputs replaces the previous unexplained volatile padding.
- `fn_800A509C`: the local block's fields sit at their retail offsets, and the previous-owner pointer is stored through a typed `Owner800A509C` structure instead of a raw offset.
- `fn_80067180`: the index table is copied as a four-word structure, the query buffer is eight words, the collision call returns unsigned, and the actor-bit block encloses the tail calls as retail branches.
- `fn_8018524C`: the flag word is read through a header pointer at `self + 0x98`, `field_94` is signed, and the position copies interleave with the entry updates.
- `fn_8017FF7C`: the record table is a byte-strided layout with the record base materialized before the slot index.
- `fn_8018D020`: the four-corner vertex sequence is `(x,y,t)`, `(z,y,t)`, `(z,w,t)`, `(x,w,t)`.
- `fn_800D9614`: the 17-argument call passes the constants in retail's order and value.
- `fn_80008014`: the slot byte offset is modeled separately from the archive index, the format string is the unit's own 26-byte `.data` object, and a configured rule sets the emitted `.data` alignment to four bytes. Its sibling `fn_80008134` was already exact and completes the object.
- `fn_80139464`: the state global is accessed directly, `free_slot` is set inside the block, and the `wanted` store precedes the `request` store.
- `fn_8012B408`: the switch cases are grouped in retail's block order; ids 66 to 68 fall to the default (the object has no data sections, so the case mapping is fixed by the code match).

### Declaration order and local lifetime

- `fn_80093264`, `fn_8018666C`, `fn_80161C30`, `fn_801B9220`, `fn_8018C6EC`, `fn_8018163C`, `fn_801A80FC`, `fn_801A81FC`, `fn_8019BDE8`, `fn_80067C20`, `fn_800CE524`, `fn_8018B058`: declarations reordered or given arithmetic-width `int` types where MWCC's numbering selected the wrong registers; `register` qualifiers removed where they were not the cause.
- `fn_80077704`, `fn_8010FB5C`, `fn_800A197C`, `fn_801A8C60`, `fn_8014549C`, `fn_80196B10`: a call result or byte value held in a named local (`runtime`, the queried `selection`, `context`, `s32 current`, `int result`, `int entry_count`) before its use.
- `fn_801C2B00`, `fn_801C2F34`: the biased secondary value is written to the result variable first, then `193 -` its shifted value.
- `fn_801C36FC`: the early-out reads the global's field directly and the pointer locals are formed after it; the loop bound is `count = sizeof(lbl_80627D60.map)`.
- `fn_80185FD0`, `fn_80186A88`: the loop's vector offset and entry count live in one two-field local structure; retail reserves that 8-byte aggregate and scalarizes it.
- `fn_8000FDE8`: the ninth script argument is a `long long` local; retail's register assignment only reproduces with a 64-bit local there.
- `fn_8017F120`: an inline `read_s16` accessor for the velocity pair after `fn_80179904`; `count` is `u8` as the byte it reads.
- `fn_8019D030`: the random bits are held in an `int bits` local before the three sign flags are derived, and the first descriptor value is held in an `int value` local.
- `fn_80113E48`, `fn_800CFA3C`: declaration placement and plain two-statement assignments (`global = ...; entry = global;`).
- `fn_801C0ED8`: the two pointer resets precede the 64-bit timing reset so the split zero store schedules as retail.
- `fn_8010F8B0`: the index lookup nests inside the resolve call.
- `fn_80185F10`: `u16 limit` with `i < limit - 1`.

### Expression and control-flow shape

- `fn_80095894`: the saturating decrement is `timer > 0 ? timer - 1 : 0`.
- `fn_8013915C`: `state->pending` is tested directly in both clauses.
- `fn_8018E504`: the two clamps use a `SUB_CLAMP0(a, b)` macro with `__abs` inline; retail evaluates the absolute value twice per clamp.
- `fn_80096710`: the packed id is `(index << 8)` in both calls.
- `fn_800DC3A0`: the sequence store narrows explicitly with `(s16)`.
- `fn_80118370`: `lbl_8064CDE0` and `lbl_8064CDA0` are `volatile` (they are written by the DVD completion callback `fn_80118288`), and the table slot is read through a `struct Entry *slot`.
- `TRKNubMainLoop`: the event switch has an explicit `case 0: break;`.
- `fn_80145754`: the zero-based offset accumulation `result += 0x37420` under a scoped `opt_propagation off`.
- `fn_801098C0`: a scoped `opt_common_subs off` keeps the two `state + 0xA0` addresses separate, as retail recomputes them.
- `fn_801CA288`: the documented single-use `DoInit` phase is a `static inline` helper.
- `fn_801C8224`: the room-status comparisons use the public literal `fade * 1.2014794e-07f >= 0.5`.

### Compiler-private literals owned by retail symbols

Guarded configured rules rebind compiler-local `.sdata2` literals to the retail symbols whose bytes they match: `fn_801C8224` (`lbl_80650FC4`, `lbl_80650FB8`, `lbl_80650FC8`), `fn_801C29BC` (`lbl_80650F50`), `fn_8014549C` (`lbl_80650470`, `lbl_80650468`), `fn_801098C0` (`lbl_8064FE68`), `fn_8000FDE8` (`lbl_8064DCE8`), `fn_80185F10` (`lbl_80650A10`). `fn_8007B828` initializes its six-byte descriptor from an initializer list; a rule in the same form as the existing `fn_8009E808` rule retargets the second load to `lbl_8064E9B8` and externalizes `lbl_8064E9B4`.

### Per-object compiler settings

- `TRKNubMainLoop` builds with `-sdata 0` like the other TRK units, so `gTRKInputPendingPtr` is addressed from `.bss` as retail does.
- `fn_801C29BC` builds with `-Cpp_exceptions on`, matching its retail `extab`/`extabindex` data.
- `fn_8014549C` uses `use_lmw_stmw on` for its `lmw`/`stmw` prologue and epilogue.

### Companion declaration changes

Ten already-matching files only change declarations to agree with the corrected interfaces and remain exact: `fn_80048C74`, `fn_80055350`, `fn_80056374`, `fn_80056624` (callers of `fn_801301B0`), `fn_801B8C28` (caller of `fn_801B3A2C`), `fn_8012E42C`, `fn_801392A8`, `fn_800F3C98`, `fn_8017BA54`, and `fn_801CC13C`. They are not counted in the totals above.

## Testing

Every function was checked with `function_reloc_diffs=name_address`:

| Function | Code bytes | Relocations | Instructions | Strict relocations |
|---|---:|---:|---:|---:|
| `fn_80008014` | 288 | 30 | 100% | equal |
| `fn_80008134` | 32 | 1 | 100% | equal |
| `fn_8000E96C` | 424 | 16 | 100% | equal |
| `fn_8000FDE8` | 496 | 20 | 100% | equal |
| `fn_80067180` | 796 | 45 | 100% | equal |
| `fn_80067C20` | 272 | 10 | 100% | equal |
| `fn_80077704` | 172 | 10 | 100% | equal |
| `fn_8007B828` | 532 | 30 | 100% | equal |
| `fn_80093264` | 316 | 17 | 100% | equal |
| `fn_80095894` | 192 | 5 | 100% | equal |
| `fn_80096710` | 288 | 15 | 100% | equal |
| `fn_800A197C` | 136 | 8 | 100% | equal |
| `fn_800A2D1C` | 92 | 3 | 100% | equal |
| `fn_800A3C4C` | 56 | 0 | 100% | equal |
| `fn_800A509C` | 660 | 57 | 100% | equal |
| `fn_800CE524` | 132 | 2 | 100% | equal |
| `fn_800CFA3C` | 456 | 21 | 100% | equal |
| `fn_800D9614` | 204 | 2 | 100% | equal |
| `fn_800DC3A0` | 308 | 8 | 100% | equal |
| `fn_800F0CC4` | 760 | 14 | 100% | equal |
| `fn_801098C0` | 532 | 23 | 100% | equal |
| `fn_8010F8B0` | 128 | 14 | 100% | equal |
| `fn_8010FB5C` | 224 | 26 | 100% | equal |
| `fn_80113E48` | 268 | 4 | 100% | equal |
| `fn_80118370` | 440 | 55 | 100% | equal |
| `fn_80127178` | 144 | 2 | 100% | equal |
| `fn_8012B408` | 548 | 0 | 100% | equal |
| `fn_8012E200` | 428 | 12 | 100% | equal |
| `fn_801301B0` | 100 | 1 | 100% | equal |
| `fn_8013915C` | 80 | 8 | 100% | equal |
| `fn_80139464` | 576 | 49 | 100% | equal |
| `fn_801397F8` | 328 | 32 | 100% | equal |
| `fn_8014549C` | 696 | 14 | 100% | equal |
| `fn_80145754` | 32 | 0 | 100% | equal |
| `fn_801493D4` | 336 | 9 | 100% | equal |
| `fn_8014B7B0` | 216 | 12 | 100% | equal |
| `fn_80161C30` | 200 | 1 | 100% | equal |
| `fn_80164A64` | 384 | 22 | 100% | equal |
| `fn_8017AE90` | 180 | 17 | 100% | equal |
| `fn_8017F120` | 660 | 4 | 100% | equal |
| `fn_8017FF7C` | 28 | 0 | 100% | equal |
| `fn_8018163C` | 80 | 5 | 100% | equal |
| `fn_80182984` | 512 | 9 | 100% | equal |
| `fn_8018524C` | 420 | 6 | 100% | equal |
| `fn_80185F10` | 192 | 3 | 100% | equal |
| `fn_80185FD0` | 500 | 19 | 100% | equal |
| `fn_8018666C` | 416 | 20 | 100% | equal |
| `fn_80186A88` | 512 | 17 | 100% | equal |
| `fn_80187A4C` | 360 | 24 | 100% | equal |
| `fn_8018B058` | 440 | 31 | 100% | equal |
| `fn_8018C6EC` | 176 | 5 | 100% | equal |
| `fn_8018D020` | 176 | 0 | 100% | equal |
| `fn_8018E504` | 948 | 2 | 100% | equal |
| `fn_80196B10` | 724 | 11 | 100% | equal |
| `fn_8019BDE8` | 440 | 24 | 100% | equal |
| `fn_8019D030` | 796 | 47 | 100% | equal |
| `fn_801A80FC` | 108 | 1 | 100% | equal |
| `fn_801A81FC` | 108 | 1 | 100% | equal |
| `fn_801A8C60` | 108 | 0 | 100% | equal |
| `fn_801B3A2C` | 220 | 25 | 100% | equal |
| `fn_801B7DC8` | 188 | 2 | 100% | equal |
| `fn_801B7E84` | 232 | 5 | 100% | equal |
| `fn_801B7F6C` | 232 | 5 | 100% | equal |
| `fn_801B8D88` | 96 | 3 | 100% | equal |
| `fn_801B8DE8` | 96 | 3 | 100% | equal |
| `fn_801B8E88` | 132 | 7 | 100% | equal |
| `fn_801B8F84` | 96 | 3 | 100% | equal |
| `fn_801B8FE4` | 148 | 4 | 100% | equal |
| `fn_801B9220` | 240 | 20 | 100% | equal |
| `fn_801C0ED8` | 104 | 10 | 100% | equal |
| `fn_801C29BC` | 240 | 16 | 100% | equal |
| `fn_801C2B00` | 628 | 4 | 100% | equal |
| `fn_801C2F34` | 416 | 6 | 100% | equal |
| `fn_801C36FC` | 452 | 39 | 100% | equal |
| `fn_801C8224` | 988 | 24 | 100% | equal |
| `fn_801CA288` | 284 | 31 | 100% | equal |
| `fn_801CAD90` | 296 | 7 | 100% | equal |
| `fn_801CAEB8` | 244 | 19 | 100% | equal |
| `fn_801CC24C` | 152 | 2 | 100% | equal |
| `TRKNubMainLoop` | 248 | 12 | 100% | equal |

The aggregate is 25,888 code bytes and 1,091 relocation sites across 80 function bodies. A clean full build completed at 33.94% matched, and `build/GEDE01/main.dol` retained SHA-1 `ea24b6af954876ce072562ff39cdb4c81d32be1f`. `python3 tools/legal_audit.py` and `git diff --check` passed.

## Other

### Approaches that did not work

Scores are objdiff instruction match percentages unless stated.

- `fn_80008014`: the unaligned form, which left the emitted `.data` alignment at eight bytes, was rejected; the slot pointer stepped by `slots[i]` indexing scored 96.11%. A 28-byte declaration of the format string matched the split object's padded section size but overstated the retail symbol, so the string is sized by its initializer (the report still shows the data 100% complete).
- `fn_8000E96C`: spelling the Z subtraction explicitly 99.76%; reversing the Z-addition operands 99.67%; expanding the vector structure assignment into fields shrank the function and scored 90.18%.
- `fn_8000FDE8`: `s32 ninth` 98.47%, best declaration order with `s32 ninth` 98.83%; `double ninth` changed the literal set; the `register void *info = script` copy was dropped as code-neutral; an exhaustive 160-combination search of type (`s32`, `long long`, `u32`, `s16`, `u16`, `double`, `float`, `short`) by position by cast form found only `long long`.
- `fn_80067180`: the tail calls outside the actor-bit block 90.13%; signed `actor` and signed collision return 98.8%; `actor` as `u32` with unsigned return 99.4% before the switch grouping.
- `fn_80067C20`: the wrap counter as `x < 2 ? x + 1 : 0` and the unsized `u16` table 88.76%; the table needs the two-entry declaration to sit in small data.
- `fn_80077704`: naming the runtime alone was code-neutral at 95.70%; the nested single-expression handle chain 95.70%.
- `fn_8007B828`: reordering the callback and descriptor initializers alone was code-neutral; retaining a direction pointer across calls 93.72% at 544 bytes; a packed-structure reconstruction left one compiler-local aggregate and was rejected; declaring the two halves as `extern` globals and copying them into the descriptor matched but hid the real initializer and was rejected.
- `fn_80093264`: swapping declarations, removing both `register` hints, a signed-byte cursor, and retaining either single hint were neutral at 99.75%; separating the identifier without correcting local order 96.71%; `i++, type++` order 99.75%.
- `fn_80095894`: the hand-expanded branchless mask form 98.75%; the same form through a reused `mask` temporary matched but was rejected as unreadable.
- `fn_80096710`: `index << 8` in a `packed` local used twice 99.03%; `index * 0x100` 99.03%; `(u8)index << 8` 98.26%; the double shift `(index << 4) << 4` matched but was replaced by `index << 8` written in both calls, which also matches.
- `fn_800A197C`: the direct cast of the call result 98.82%.
- `fn_800A2D1C`: none recorded; the first prototype hypothesis matched.
- `fn_800A3C4C`: typing the callback as two arguments only was code-neutral at 98.21%.
- `fn_800A509C`: declaration move alone 97.95%; the raw `*(void**)((u8*)owner + 0xBC)` store matched and was replaced by the typed structure, which also matches.
- `fn_800CE524`: the `Entry *entry` pointer form 96.36%; array indexing with `index` declared first 98.48%; array indexing with `index` declared last 98.48%.
- `fn_800CFA3C`: the single-expression `entry = (global = ...)` form and a zero held in an `argument` local matched but were rejected as unreadable; the plain two-statement form also matches. Baseline 98.11%.
- `fn_800D9614`: the previous constant order 90.53%.
- `fn_800DC3A0`: an `s16 sequence_arg` parameter 97.14%.
- `fn_800F0CC4`: 719 declaration permutations, explicit copies, operand flips, split locals, 30 compiler and flag combinations, and `long` substitutions stayed at 99.89%; `static inline` alone fixed only the object boundary.
- `fn_801098C0`: `(u8*)state + 0xA0` without the pragma 97.22% at 544 bytes (the address is shared across the two calls); `(void*)((u32)state + 0xA0)` matched but was rejected as a pointer-to-integer trick; `(u32)` on the float-to-int store called `__cvt_fp2unsigned` (baseline 83.12%).
- `fn_8010F8B0`: the two-statement form 96.09%.
- `fn_8010FB5C`: the nested call form 97.77%.
- `fn_80113E48`: a `masked` copy of the table entry matched and was dropped as code-neutral; baseline 97.81%.
- `fn_80118370`: the slot pointer alone 98.53%; swapping the two stores 98.66%; `volatile` on one global 98.53%; `volatile` on both without the slot pointer 98.82%; an `index` local 98.82%.
- `fn_80127178`: state-before-pending declaration order and initializers were neutral at 98.89%; the `volatile` pair was removed as unsupported by the code.
- `fn_8012B408`: the previous case grouping 85.14%.
- `fn_8012E200`: pointer argument with every declaration order 88.56%.
- `fn_8013915C`: state-before-pending declaration order and declaration initializers were neutral at 98.00%.
- `fn_80139464`: pointer-local access to the state 64.10%; direct access with the old store order 97.5%.
- `fn_8014549C`: `int result` first with the pragma 92.4% before the two literal rules.
- `fn_80145754`: the one-case switch 86.25%; conditional returns 59.88%; a default return inside the switch 28.75%; returns from both cases 66.25%; `if`/`else` 28.75%; `opt_propagation off` on the switch was neutral; the accumulating form at `-O0` through `-O3` and `-O4` without the pragma 59.88% to 86.25%.
- `fn_801493D4`: none recorded; the first repository-evidenced layout matched.
- `fn_8014B7B0`: the previous `volatile` padding was removed because it neither changed code nor represented program logic.
- `fn_80161C30`: bucket offset and `register` qualifiers were neutral at 98.7%; a semantic rename of the link 86.36%; `node = *link` in the `while` condition alone 97.5%; moving the work offset to function scope 98.9%.
- `fn_80164A64`: the ABI correction with explicit `index` and `values` locals 99.53%.
- `fn_8017AE90`: `(void*, void*)` with two explicit null pointers, an implicit second null conversion, and `(Callback, void*)` were all 99.78%.
- `fn_8017F120`: no inline accessor 98.09%; `int count` 99.27%; `char count` matched and was replaced by `u8`; an `item` alias was dropped as code-neutral; an `s16 *velocity` local 93.59% to 98.09%; `dx`/`dy` temporaries in the first loop 86.58% to 87.98%; an exhaustive 1,296-combination search of read spelling, count type, and declaration slot found nothing better.
- `fn_8017FF7C`: a single flat byte-offset expression 70%; a typed 0x38-byte record 32.86%.
- `fn_8018163C`: reversing the two local declarations was neutral at 98.75%.
- `fn_80182984`: block and function locals 99.83%; reversed equality 99.79%; signed and all-`u8` prototypes 99.13% and 99.06% at 516 bytes; signed-byte and promoted-int locals 95.84% and 99.40%; a value cast instead of signed storage 99.13% at 516 bytes.
- `fn_8018524C`: a saved `self` alias 92.76%.
- `fn_80185F10`: `int limit` with `limit -= 1` in the loop header 99.48%; `int limit = self[1] - 1` 98.85%; `u8 limit` 92.40%; the decrement as a statement 99.48%; the `u16` form then needed only the literal rule.
- `fn_80185FD0`: plain `int` offset and count in any of ten declaration orders 97.64% to 99.04%; a `u8 count` 97.64%; the two values as extra `Locals` fields 91.39%; two extra unused `Locals` fields with plain locals 97.64%; an exhaustive 1,125-combination search of count type, declaration slot, and re-read form reached 99.04% at best; an `int loop[2]` array also matches but was replaced by the named structure.
- `fn_80186A88`: plain `int` offset and count 97.54% to 99.06% over the same sweep; the two extra `Locals` fields 91.4%; an `int loop[2]` array with a `state_bytes` alias matched and was replaced by the same structure its twin uses.
- `fn_8018666C`: mutating the byte input count 96.30%; a distinct `fill` cursor alone 99.47%.
- `fn_80187A4C`: an `int` third parameter on `fn_801805E0` matched but contradicted the callee's proven `u8`; an explicit truncation on the halved path only 98.67%; on the unhalved path only 98.67%.
- `fn_8018B058`: `register u16 index; register int i;` 99.59%; `index` as the loop variable 97.18%; block-scoped `index` 99.59%; a 24-combination sweep of `register`, `int`, and `u16` on both locals with `(u16)i` or `i & 0xFFFF` found only the plain `int` pair with `(u16)i` and `register u16 i` with `i & 0xFFFF`; the mask form was rejected as a no-op.
- `fn_8018C6EC`: mutating the input base pointer 98.07%.
- `fn_8018D020`: none recorded; the corrected corner order matched first.
- `fn_8018E504`: manual absolute-value blocks 93.71%; an `amount` local 92.78%; an `s8` or `int` delta local with four `__abs` calls 97.64%; four inline `__abs` calls matched and were folded into the macro, which also matches.
- `fn_8019BDE8`: the direct `*(u16*)(config + 0x16)` argument 98.07%.
- `fn_8019D030`: `config[1]` unmasked 99.40%; `config[1] & 0xFFu` matched and was rejected; a `u8` local 99.40%; the `int` local at all three call sites 91.55%.
- `fn_801A80FC`, `fn_801A81FC`: declaration order alone and `int` width alone were neutral at 98.89%.
- `fn_801A8C60`: a `u8 current` with `*value = current + step` 91.48%.
- `fn_801B3A2C`: `entry` declared first, per-branch locals, and `i` before `entry` 98.45%; `entry` computed once before the branch 86.82%; a `u16 *slot` walker 96.25%.
- `fn_801B7DC8`: unsigned result alone 99.89%; narrow wrapper parameters with imprecise callees 95.32% at 192 bytes; wide wrapper parameters with precise callees 95.21% at 192 bytes.
- `fn_801B7E84`, `fn_801B7F6C`: narrow signatures with a cast-form index 95.17% at 240 bytes.
- `fn_801B8D88`, `fn_801B8DE8`, `fn_801B8F84`, `fn_801B8FE4`: baselines 99.63%, 99.63%, 99.63%, 99.70% with `int` parameters; the public widths matched first.
- `fn_801B8E88`: applying the public signature to the still-unmatched `fn_801B64D0` worsened it from 92.23% to 84.76% and was reverted there.
- `fn_801B9220`: none recorded; the two declaration corrections matched first.
- `fn_801C0ED8`: the previous store order was instruction-exact at strict 99.42% because the three zero-store relocation names rotated.
- `fn_801C29BC`: an explicit byte local 98.92%; the unsigned domain alone 99.75% before the literal rule.
- `fn_801C2B00`, `fn_801C2F34`: the single-expression form 99.30% and 98.94%.
- `fn_801C36FC`: without the loop-bound local 99.96% (the frame is eight bytes short); a `u8 slot` local 97.08%; a `u32 handle` local 91.46%; the previous `u32 unused[1]` filler matched and was rejected.
- `fn_801C8224`: declaration order 99.72%; an explicit count cast neutral at 99.76%; block-scope initialized locals 98.07%; direct named externals 94.30%.
- `fn_801CA288`: a scalar config word or reduced frame 99.85%; a tail field or array 97.46%; a named tail pointer 95.21% at 288 bytes; an alignment attribute 99.85%; a retained voice pointer 93.24% at 280 bytes; a non-inline `DoInit` left a 144-byte out-of-line body.
- `fn_801CAD90`: narrow widths with compact range expressions 99.86%; widening only `control` 98.38% at 300 bytes; widening both `control` and its callee matched but contradicted the callee and was rejected.
- `fn_801CAEB8`: none recorded; the first signature hypothesis matched.
- `fn_801CC24C`: narrowing only the outgoing callee 97.92%; value signedness alone, promoting all outgoing parameters, and a separate clamped local were neutral at 99.76%.
- `fn_801301B0`: `value` declared first, no locals with compound assignment, plain assignment, a `runtime` local only, and `u8 value` were all 98.40%.
- `fn_801397F8`: discarding the loaded buffer 69.55%; returning the pointer cast to `int` matched and was rejected in favor of the pointer return type.
- `fn_80196B10`: `count` local as `u8`, `u16`, or `int` at the top 97.79%; the callee prototype's third parameter as `u16` or `int` with the plain argument 97.79%; a `values` local for the first argument 96.61%; `(u16)object[1]` and `(int)object[1]` casts matched and were replaced by the named local.
- `TRKNubMainLoop`: `case 0` alone 95.81%; an in-file `#pragma sdata 0` had no effect; `__declspec(section)` and `#pragma section` forms did not compile; an array declaration of `gTRKInputPendingPtr` matched and was rejected.
- `fn_8018B058`, `fn_80196B10`, `fn_800CE524`, `fn_800DC3A0`, `fn_80185F10` were first reached by automated source mutation whose raw outputs used hoisted temporaries, inline wrappers, and no-op masks; those outputs were not used, and the plain forms above were derived and verified separately.
- `fn_80008134`: already exact before this change; it shares its object with `fn_80008014` and is listed because the object is now complete.
