### PR TITLE
Match 53 game functions with control-flow, type, and data-ownership corrections

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -346,6 +346,114 @@ config.custom_build_rules = [
         "description": "EXTERNALIZE $in",
     },
     {
+        "name": "externalize_game_8004998C_tables_and_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @205 jumptable_8023EF84 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @206 jumptable_8023EF34 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @207 jumptable_8023EEE4 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @208 jumptable_8023EE94 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @210 lbl_8064E3D0 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@205=jumptable_8023EF84 --redefine-sym=@206=jumptable_8023EF34 "
+            "--redefine-sym=@207=jumptable_8023EEE4 --redefine-sym=@208=jumptable_8023EE94 "
+            "--redefine-sym=@210=lbl_8064E3D0 "
+            "--remove-section=.data --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_801816D4_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @13 lbl_80650970 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@13=lbl_80650970 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_8011F140_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @11 lbl_80650088 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@11=lbl_80650088 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_801AD08C_jumptable",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @82 jumptable_802517CC orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@82=jumptable_802517CC --remove-section=.data "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_8008F224_jumptable",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @34 jumptable_802451E0 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@34=jumptable_802451E0 --remove-section=.data "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_80167454_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @18 lbl_80650660 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@18=lbl_80650660 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_80079AA4_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @27 lbl_8064E930 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@27=lbl_8064E930 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_801A3A78_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @22 lbl_80650D58 orig/GEDE01/sys/main.dol && "
+            "python3 tools/externalize_elf_symbol.py $in @25 lbl_80650D60 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@22=lbl_80650D58 --redefine-sym=@25=lbl_80650D60 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_80158D38_conversion_bias",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @23 lbl_80650628 orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@23=lbl_80650628 --remove-section=.sdata2 "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
+        "name": "externalize_game_800AF230_id_table",
+        "command": (
+            "python3 tools/externalize_elf_symbol.py $in @6 lbl_8023979C orig/GEDE01/sys/main.dol && "
+            "build/binutils/powerpc-eabi-objcopy "
+            "--redefine-sym=@6=lbl_8023979C --remove-section=.rodata "
+            "--rename-section=.comment=.ignored $in && touch $out"
+        ),
+        "description": "EXTERNALIZE $in",
+    },
+    {
         "name": "externalize_game_801AB154_conversion_biases",
         "command": (
             "python3 tools/externalize_elf_symbol.py $in @29 lbl_80650E80 orig/GEDE01/sys/main.dol && "
@@ -2785,6 +2893,56 @@ config.custom_build_steps = {
             "outputs": [f"build/{VERSION}/src/game/game_fn_801ABD3C.externalized"],
             "rule": "externalize_game_801ABD3C_table_and_conversion_bias",
             "inputs": [f"build/{VERSION}/src/game/game_fn_801ABD3C.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8004998C.externalized"],
+            "rule": "externalize_game_8004998C_tables_and_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8004998C.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_801816D4.externalized"],
+            "rule": "externalize_game_801816D4_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_801816D4.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8011F140.externalized"],
+            "rule": "externalize_game_8011F140_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8011F140.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_801AD08C.externalized"],
+            "rule": "externalize_game_801AD08C_jumptable",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_801AD08C.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_80079AA4.externalized"],
+            "rule": "externalize_game_80079AA4_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_80079AA4.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_801A3A78.externalized"],
+            "rule": "externalize_game_801A3A78_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_801A3A78.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_80158D38.externalized"],
+            "rule": "externalize_game_80158D38_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_80158D38.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_8008F224.externalized"],
+            "rule": "externalize_game_8008F224_jumptable",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_8008F224.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_80167454.externalized"],
+            "rule": "externalize_game_80167454_conversion_bias",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_80167454.o"],
+        },
+        {
+            "outputs": [f"build/{VERSION}/src/game/game_fn_800AF230.externalized"],
+            "rule": "externalize_game_800AF230_id_table",
+            "inputs": [f"build/{VERSION}/src/game/game_fn_800AF230.o"],
         },
         {
             "outputs": [f"build/{VERSION}/src/game/game_fn_801AB154.externalized"],
@@ -5344,8 +5502,8 @@ config.libs = [
     Object(Matching, "game/game_fn_80049694.c"),
     Object(Matching, "game/game_fn_800496EC.c"),
     Object(Matching, "game/game_fn_80049774.c"),
-    Object(NonMatching, "game/game_fn_80049818.c"),
-    Object(NonMatching, "game/game_fn_8004998C.c"),
+    Object(Matching, "game/game_fn_80049818.c"),
+    Object(Matching, "game/game_fn_8004998C.c"),
     Object(NonMatching, "game/game_fn_80049E74.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80050728.c"),
     Object(Matching, "game/game_fn_80050730.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -5723,9 +5881,9 @@ config.libs = [
     Object(Matching, "game/game_fn_800681A0.c"),
     Object(Matching, "game/game_fn_800681C8.c"),
     Object(Matching, "game/game_fn_80068230.c"),
-    Object(NonMatching, "game/game_fn_80068290.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_80068290.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_800683E4.c"),
-    Object(NonMatching, "game/game_fn_8006845C.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8006845C.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_data_800685A4.c"),
     Object(Matching, "game/game_fn_800685A4.c"),
     Object(Matching, "game/game_fn_80068668.c"),
@@ -5799,7 +5957,7 @@ config.libs = [
     Object(Matching, "game/game_fn_8006E644.c"),
     Object(Matching, "game/game_fn_8006E6EC.c"),
     Object(NonMatching, "game/game_fn_8006E754.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_8006EA4C.c"),
+    Object(Matching, "game/game_fn_8006EA4C.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_8006EB60.c"),
     Object(Matching, "game/game_fn_8006EC74.c"),
     Object(Matching, "game/game_fn_8006EC8C.c"),
@@ -5839,7 +5997,7 @@ config.libs = [
     Object(Matching, "game/game_fn_80072070.c"),
     Object(Matching, "game/game_fn_80072354.c"),
     Object(Matching, "game/game_fn_80072368.c"),
-    Object(NonMatching, "game/game_fn_800723A8.c"),
+    Object(Matching, "game/game_fn_800723A8.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8007249C.c"),
     Object(Matching, "game/game_fn_800724F8.c"),
     Object(Matching, "game/game_fn_8007255C.c"),
@@ -5877,7 +6035,7 @@ config.libs = [
     Object(NonMatching, "game/game_fn_8007930C.c"),
     Object(Matching, "game/game_fn_800798C4.c"),
     Object(Matching, "game/game_fn_80079908.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_80079AA4.c"),
+    Object(Matching, "game/game_fn_80079AA4.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_80079C50.c"),
     Object(NonMatching, "game/game_fn_80079D24.c"),
     Object(Matching, "game/game_fn_8007A1C0.c"),
@@ -5948,7 +6106,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800878F4.c"),
     Object(Matching, "game/game_fn_8008799C.c"),
     Object(Matching, "game/game_fn_800879E0.c"),
-    Object(NonMatching, "game/game_fn_80087A24.c"),
+    Object(Matching, "game/game_fn_80087A24.c"),
     Object(NonMatching, "game/game_fn_80087BA8.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_80087D64.c"),
     Object(NonMatching, "game/game_fn_80087EC4.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -6011,15 +6169,15 @@ config.libs = [
     Object(Matching, "game/game_fn_8008D31C.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008D4B4.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(NonMatching, "game/game_fn_8008D5D4.c"),
-    Object(NonMatching, "game/game_fn_8008D6E4.c"),
-    Object(NonMatching, "game/game_fn_8008D9F4.c"),
+    Object(Matching, "game/game_fn_8008D6E4.c"),
+    Object(Matching, "game/game_fn_8008D9F4.c"),
     Object(NonMatching, "game/game_fn_8008DBA8.c"),
     Object(Matching, "game/game_fn_8008DD24.c"),
     Object(NonMatching, "game/game_fn_8008DD78.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008DF64.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008E078.c"),
-    Object(NonMatching, "game/game_fn_8008E110.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_8008E294.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8008E110.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8008E294.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008E3D8.c"),
     Object(NonMatching, "game/game_fn_8008E430.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008E670.c"),
@@ -6030,7 +6188,7 @@ config.libs = [
     Object(Matching, "game/game_fn_8008EF28.c"),
     Object(Matching, "game/game_fn_8008EFA8.c"),
     Object(Matching, "game/game_fn_8008F064.c", extra_cflags=["-use_lmw_stmw on"]),
-    Object(NonMatching, "game/game_fn_8008F224.c", extra_cflags=["-use_lmw_stmw on"]),
+    Object(Matching, "game/game_fn_8008F224.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008F5B4.c", extra_cflags=["-use_lmw_stmw on"]),
     Object(Matching, "game/game_fn_8008F860.c"),
     Object(Matching, "game/game_fn_8008F890.c"),
@@ -6202,7 +6360,7 @@ config.libs = [
     Object(Matching, "game/game_fn_800A30C0.c"),
     Object(Matching, "game/game_fn_800A30CC.c"),
     Object(Matching, "game/game_fn_800A30F4.c"),
-    Object(NonMatching, "game/game_fn_800A3104.c"),
+    Object(Matching, "game/game_fn_800A3104.c"),
     Object(Matching, "game/game_fn_800A3180.c"),
     Object(Matching, "game/game_fn_800A3240.c"),
     Object(Matching, "game/game_fn_800A3274.c"),
@@ -6277,7 +6435,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_800AA94C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_800AAAB8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_800AAB90.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_800AAD14.c"),
+            Object(Matching, "game/game_fn_800AAD14.c"),
             Object(Matching, "game/game_fn_800ACED0.c"),
             Object(Matching, "game/game_fn_800ACFE0.c"),
             Object(Matching, "game/game_fn_800ACFE8.c"),
@@ -6314,7 +6472,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800AF0AC.c"),
             Object(Matching, "game/game_fn_800AF11C.c"),
             Object(Matching, "game/game_fn_800AF1C0.c"),
-            Object(NonMatching, "game/game_fn_800AF230.c"),
+            Object(Matching, "game/game_fn_800AF230.c"),
             Object(Matching, "game/game_fn_800AF2D4.c"),
             Object(Matching, "game/game_fn_800AF6D4.c"),
             Object(Matching, "game/game_fn_800AF6DC.c"),
@@ -6325,7 +6483,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800AFDA4.c"),
             Object(Matching, "game/game_fn_800AFE30.c"),
             Object(Matching, "game/game_fn_800AFEC0.c"),
-            Object(NonMatching, "game/game_fn_800B002C.c"),
+            Object(Matching, "game/game_fn_800B002C.c"),
             Object(Matching, "game/game_fn_800B01D8.c"),
             Object(Matching, "game/game_fn_800B035C.c"),
             Object(Matching, "game/game_fn_800B0954.c"),
@@ -6426,7 +6584,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800B811C.c"),
             Object(Matching, "game/game_fn_800B84A8.c"),
             Object(Matching, "game/game_fn_800B84C8.c"),
-            Object(NonMatching, "game/game_fn_800B84DC.c"),
+            Object(Matching, "game/game_fn_800B84DC.c"),
             Object(Matching, "game/game_fn_800B8DBC.c"),
             Object(Matching, "game/game_fn_800B8E28.c"),
             Object(Matching, "game/game_fn_800B8F38.c"),
@@ -6508,7 +6666,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800C17EC.c"),
             Object(Matching, "game/game_fn_800C1AB8.c"),
             Object(Matching, "game/game_fn_800C1D54.c"),
-            Object(NonMatching, "game/game_fn_800C1D60.c"),
+            Object(Matching, "game/game_fn_800C1D60.c"),
             Object(Matching, "game/game_fn_800C23D8.c"),
             Object(Matching, "game/game_fn_800C2528.c"),
             Object(Matching, "game/game_fn_800C262C.c"),
@@ -6793,7 +6951,7 @@ config.libs = [
             Object(Matching, "game/game_fn_800DE8FC.c"),
             Object(Matching, "game/game_fn_800DEA28.c"),
             Object(Matching, "game/game_fn_800DEA88.c"),
-            Object(NonMatching, "game/game_fn_800DFD54.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_800DFD54.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_800DFEB0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_800E0330.c"),
             Object(Matching, "game/game_fn_800E05BC.c"),
@@ -7296,13 +7454,13 @@ config.libs = [
             Object(Matching, "game/game_fn_8011F114.c"),
             Object(Matching, "game/game_fn_8011F130.c"),
             Object(Matching, "game/game_fn_8011F134.c"),
-            Object(NonMatching, "game/game_fn_8011F140.c"),
+            Object(Matching, "game/game_fn_8011F140.c"),
             Object(Matching, "game/game_fn_8011F220.c"),
             Object(Matching, "game/game_fn_8011F244.c"),
             Object(Matching, "game/game_fn_8011F2B8.c"),
             Object(Matching, "game/game_fn_8011F304.c"),
             Object(Matching, "game/game_fn_8011F3B4.c"),
-            Object(NonMatching, "game/game_fn_8011F41C.c"),
+            Object(Matching, "game/game_fn_8011F41C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8011F574.c"),
             Object(NonMatching, "game/game_fn_8011F598.c"),
             Object(Matching, "game/game_fn_8011F6A4.c"),
@@ -7425,7 +7583,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_80124DBC.c"),
             Object(Matching, "game/game_fn_80125284.c"),
             Object(Matching, "game/game_fn_801252D8.c"),
-            Object(NonMatching, "game/game_fn_80125664.c"),
+            Object(Matching, "game/game_fn_80125664.c"),
             Object(Matching, "game/game_fn_80125D1C.c"),
             Object(Matching, "game/game_fn_80125D50.c"),
             Object(Matching, "game/game_fn_80125D88.c"),
@@ -7583,7 +7741,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8012C46C.c"),
             Object(Matching, "game/game_fn_8012C478.c"),
             Object(Matching, "game/game_fn_8012C5B0.c"),
-            Object(NonMatching, "game/game_fn_8012C62C.c"),
+            Object(Matching, "game/game_fn_8012C62C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8012C774.c"),
             Object(NonMatching, "game/game_fn_8012C804.c"),
             Object(Matching, "game/game_fn_8012CAC4.c"),
@@ -7617,7 +7775,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8012F674.c"),
             Object(Matching, "game/game_fn_8012F6E8.c"),
             Object(NonMatching, "game/game_fn_8012F700.c"),
-            Object(NonMatching, "game/game_fn_8012F7D4.c"),
+            Object(Matching, "game/game_fn_8012F7D4.c"),
             Object(NonMatching, "game/game_fn_8012F8CC.c"),
             Object(Matching, "game/game_fn_8012FA54.c"),
             Object(Matching, "game/game_fn_8012FAB4.c"),
@@ -7689,7 +7847,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80134F7C.c"),
             Object(Matching, "game/game_fn_80134FD8.c"),
             Object(Matching, "game/game_fn_80134FF8.c"),
-            Object(NonMatching, "game/game_fn_8013507C.c"),
+            Object(Matching, "game/game_fn_8013507C.c"),
             Object(Matching, "game/game_fn_8013523C.c"),
             Object(Matching, "game/game_fn_8013530C.c"),
             Object(Matching, "game/game_fn_8013535C.c"),
@@ -7735,7 +7893,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8013898C.c"),
             Object(Matching, "game/game_fn_80138994.c"),
             Object(NonMatching, "game/game_fn_80138A6C.c"),
-            Object(NonMatching, "game/game_fn_80138B90.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80138B90.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80138CD4.c"),
             Object(Matching, "game/game_fn_80138D2C.c"),
             Object(Matching, "game/game_fn_80138DB4.c"),
@@ -7747,7 +7905,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801390D4.c"),
             Object(Matching, "game/game_fn_8013915C.c"),
             Object(Matching, "game/game_fn_801391AC.c"),
-            Object(NonMatching, "game/game_fn_801391D4.c"),
+            Object(Matching, "game/game_fn_801391D4.c"),
             Object(Matching, "game/game_fn_80139298.c"),
             Object(NonMatching, "game/game_fn_801392A8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80139464.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -7755,7 +7913,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8013977C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801397F8.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80139940.c"),
-            Object(NonMatching, "game/game_fn_801399CC.c"),
+            Object(Matching, "game/game_fn_801399CC.c"),
             Object(NonMatching, "game/game_fn_80139B1C.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80139C1C.c"),
             Object(Matching, "game/game_fn_80139C74.c"),
@@ -7803,7 +7961,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8013E028.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8013E188.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8013E284.c"),
-            Object(NonMatching, "game/game_fn_8013E714.c"),
+            Object(Matching, "game/game_fn_8013E714.c"),
             Object(Matching, "game/game_fn_8013EA5C.c"),
             Object(NonMatching, "game/game_fn_8013EB90.c"),
             Object(Matching, "game/game_fn_8013EF30.c"),
@@ -7822,9 +7980,9 @@ config.libs = [
             Object(Matching, "game/game_fn_8013FBE4.c"),
             Object(NonMatching, "game/game_fn_8013FDB4.c"),
             Object(Matching, "game/game_fn_8013FF44.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_80140010.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80140010.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_80140258.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_80140408.c"),
+            Object(Matching, "game/game_fn_80140408.c"),
             Object(Matching, "game/game_fn_801409A8.c"),
             Object(Matching, "game/game_fn_801409AC.c"),
             Object(NonMatching, "game/game_fn_801409C0.c"),
@@ -7864,7 +8022,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801446FC.c"),
             Object(Matching, "game/game_fn_80144710.c"),
             Object(NonMatching, "game/game_fn_80144760.c"),
-            Object(NonMatching, "game/game_fn_80144A2C.c"),
+            Object(Matching, "game/game_fn_80144A2C.c"),
             Object(Matching, "game/game_fn_80144C40.c"),
             Object(NonMatching, "game/game_fn_80144C4C.c"),
             Object(Matching, "game/game_fn_80144E78.c"),
@@ -7979,7 +8137,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8014CB90.c"),
             Object(Matching, "game/game_fn_8014CBC0.c"),
             Object(Matching, "game/game_fn_8014CBE8.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8014CCB0.c"),
+            Object(Matching, "game/game_fn_8014CCB0.c"),
             Object(Matching, "game/game_fn_8014CE98.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8014CFF4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8014D100.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -8074,7 +8232,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80154F10.c"),
             Object(NonMatching, "game/game_fn_80154F74.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801550C8.c"),
-            Object(NonMatching, "game/game_fn_80155158.c"),
+            Object(Matching, "game/game_fn_80155158.c"),
             Object(Matching, "game/game_fn_801552AC.c"),
             Object(NonMatching, "game/game_fn_80155330.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801555D4.c"),
@@ -8114,7 +8272,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801562E8.c"),
             Object(Matching, "game/game_fn_801563C0.c"),
             Object(Matching, "game/game_fn_8015644C.c"),
-            Object(NonMatching, "game/game_fn_80156480.c"),
+            Object(Matching, "game/game_fn_80156480.c"),
             Object(Matching, "game/game_fn_801565E0.c"),
             Object(Matching, "game/game_fn_8015662C.c"),
             Object(Matching, "game/game_fn_801566E0.c"),
@@ -8267,7 +8425,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80158B20.c"),
             Object(Matching, "game/game_fn_80158C0C.c"),
             Object(Matching, "game/game_fn_80158CC8.c"),
-            Object(NonMatching, "game/game_fn_80158D38.c"),
+            Object(Matching, "game/game_fn_80158D38.c"),
             Object(NonMatching, "game/game_fn_80158E7C.c"),
             Object(Matching, "game/game_fn_80158E84.c"),
             Object(Matching, "game/game_fn_80158E88.c"),
@@ -8483,7 +8641,7 @@ config.libs = [
             Object(Matching, "game/game_fn_8016160C.c"),
             Object(Matching, "game/game_fn_8016166C.c"),
             Object(Matching, "game/game_fn_801616EC.c"),
-            Object(NonMatching, "game/game_fn_80161798.c"),
+            Object(Matching, "game/game_fn_80161798.c"),
             Object(Matching, "game/game_fn_801618D0.c"),
             Object(Matching, "game/game_fn_80161948.c"),
             Object(Matching, "game/game_fn_801619BC.c"),
@@ -8627,7 +8785,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801672C8.c"),
             Object(Matching, "game/game_fn_8016731C.c"),
             Object(Matching, "game/game_fn_80167380.c"),
-            Object(NonMatching, "game/game_fn_80167454.c"),
+            Object(Matching, "game/game_fn_80167454.c"),
             Object(Matching, "game/game_fn_80167558.c"),
             Object(Matching, "game/game_fn_80167798.c"),
             Object(Matching, "game/game_fn_8016783C.c"),
@@ -9276,7 +9434,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80181530.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018163C.c"),
             Object(Matching, "game/game_fn_8018168C.c"),
-            Object(NonMatching, "game/game_fn_801816D4.c"),
+            Object(Matching, "game/game_fn_801816D4.c"),
             Object(Matching, "game/game_fn_80181808.c"),
             Object(Matching, "game/game_fn_8018183C.c"),
             Object(NonMatching, "game/game_fn_80181870.c"),
@@ -9399,7 +9557,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801878D0.c"),
             Object(Matching, "game/game_fn_801878D8.c"),
             Object(Matching, "game/game_fn_801878E0.c"),
-            Object(NonMatching, "game/game_fn_80187968.c"),
+            Object(Matching, "game/game_fn_80187968.c"),
             Object(Matching, "game/game_fn_801879E8.c"),
             Object(Matching, "game/game_fn_80187A34.c"),
             Object(Matching, "game/game_fn_80187A3C.c"),
@@ -9450,7 +9608,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_8018AA30.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018ABD4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_8018AD14.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_8018AEB0.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_8018AEB0.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018B058.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018B210.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8018B3C8.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9615,7 +9773,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80194F80.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801950D4.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_801952E8.c", extra_cflags=["-use_lmw_stmw on"]),
-            Object(NonMatching, "game/game_fn_801957EC.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801957EC.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_80195960.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(NonMatching, "game/game_fn_80195AEC.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801964E8.c", extra_cflags=["-use_lmw_stmw on"]),
@@ -9671,7 +9829,7 @@ config.libs = [
             Object(Matching, "game/game_fn_80199B84.c"),
             Object(Matching, "game/game_fn_80199E18.c"),
             Object(Matching, "game/game_fn_80199EBC.c"),
-            Object(NonMatching, "game/game_fn_80199F10.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_80199F10.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_8019A0DC.c"),
             Object(Matching, "game/game_fn_8019A150.c"),
             Object(Matching, "game/game_fn_8019A300.c"),
@@ -9818,7 +9976,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801A39B8.c"),
             Object(Matching, "game/game_fn_801A39D4.c"),
             Object(Matching, "game/game_fn_801A39DC.c"),
-            Object(NonMatching, "game/game_fn_801A3A78.c", extra_cflags=["-use_lmw_stmw on"]),
+            Object(Matching, "game/game_fn_801A3A78.c", extra_cflags=["-use_lmw_stmw on"]),
             Object(Matching, "game/game_fn_801A3D18.c"),
             Object(NonMatching, "game/game_fn_801A3DF8.c"),
             Object(Matching, "game/game_fn_801A42A0.c"),
@@ -9846,8 +10004,8 @@ config.libs = [
             Object(Matching, "game/game_fn_801A5854.c"),
             Object(Matching, "game/game_fn_801A5860.c"),
             Object(Matching, "game/game_fn_801A58FC.c"),
-            Object(NonMatching, "game/game_fn_801A5910.c"),
-            Object(NonMatching, "game/game_fn_801A59CC.c"),
+            Object(Matching, "game/game_fn_801A5910.c"),
+            Object(Matching, "game/game_fn_801A59CC.c"),
             Object(Matching, "game/game_fn_801A5AA0.c"),
             Object(Matching, "game/game_fn_801A5B70.c"),
             Object(Matching, "game/game_fn_801A5BA0.c"),
@@ -10004,7 +10162,7 @@ config.libs = [
             Object(NonMatching, "game/game_fn_801A7958.c"),
             Object(NonMatching, "game/game_fn_801A7BA0.c"),
             Object(Matching, "game/game_fn_801A7D20.c"),
-            Object(NonMatching, "game/game_fn_801A7D44.c"),
+            Object(Matching, "game/game_fn_801A7D44.c"),
             Object(Matching, "game/game_fn_801A7DEC.c"),
             Object(Matching, "game/game_fn_801A7DFC.c"),
             Object(Matching, "game/game_fn_801A7E04.c"),
@@ -10119,7 +10277,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801AA9FC.c", extra_cflags=["-schedule off"]),
             Object(NonMatching, "game/game_fn_801AAA28.c", extra_cflags=["-schedule off"]),
             Object(Matching, "game/game_fn_801AAAD8.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801AAB38.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801AAB38.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(NonMatching, "game/game_fn_801AAC10.c", extra_cflags=["-schedule off"]),
             Object(Matching, "game/game_fn_801AAD48.c"),
             Object(Matching, "game/game_fn_801AAD58.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
@@ -10160,7 +10318,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801ACF80.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801ACFB0.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801ACFE8.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
-            Object(NonMatching, "game/game_fn_801AD08C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
+            Object(Matching, "game/game_fn_801AD08C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AD404.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AD46C.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
             Object(Matching, "game/game_fn_801AD490.c", extra_cflags=["-schedule off", "-opt nopeephole"]),
@@ -10411,7 +10569,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801BE474.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801BE5A0.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801BE740.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801BE874.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801BE874.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801BE9D8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801BEA3C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801BEAA4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
@@ -10489,7 +10647,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801C753C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(NonMatching, "game/game_fn_801C7580.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C7624.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
-            Object(NonMatching, "game/game_fn_801C7684.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
+            Object(Matching, "game/game_fn_801C7684.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
             Object(Matching, "game/game_fn_801C773C.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801C77E4.c", mw_version="GC/1.2.5n"),
             Object(Matching, "game/game_fn_801C7868.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on"]),
@@ -10522,7 +10680,7 @@ config.libs = [
             Object(Matching, "game/game_fn_801CA3A4.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA3D8.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA538.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
-            Object(NonMatching, "game/game_fn_801CA59C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
+            Object(Matching, "game/game_fn_801CA59C.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CA798.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(NonMatching, "game/game_fn_801CA7C0.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),
             Object(Matching, "game/game_fn_801CAD90.c", mw_version="GC/1.2.5n", extra_cflags=["-Cpp_exceptions on", "-fp_contract off"]),

--- a/src/game/game_fn_80049818.c
+++ b/src/game/game_fn_80049818.c
@@ -2,14 +2,13 @@ typedef unsigned short u16;
 
 extern u16 fn_8012A244(int value);
 extern int fn_8011EB04(void *);
-#define fn_8011EB04(a) fn_8011EB04((void *)(a))
 extern int fn_801A9EF4(int minimum, int maximum);
 
 u16 fn_80049818(int value)
 {
     int state = fn_8012A244(value);
     u16 result = 0xFFFF;
-    int type = fn_8011EB04(value);
+    int type = fn_8011EB04((void*)value);
 
     if (state >= 21 || state < 0) {
         state = 0;
@@ -32,18 +31,46 @@ u16 fn_80049818(int value)
     case 0xE5:
     case 0xE6:
     case 0xE7:
-        if (state >= 10 && state < 12) {
+        switch (state) {
+        case 10:
+        case 11:
             result = fn_801A9EF4(0x1E9, 0x1EE);
-        } else {
+            break;
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        default:
             result = fn_801A9EF4(0x28, 0x32);
+            break;
         }
         break;
     case 0x70:
     case 0xE9:
-        if (state >= 10 && state < 12) {
+        switch (state) {
+        case 10:
+        case 11:
             result = fn_801A9EF4(0x2A2, 0x2A3);
-        } else {
+            break;
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        default:
             result = 0x2A5;
+            break;
         }
         break;
     }

--- a/src/game/game_fn_8004998C.c
+++ b/src/game/game_fn_8004998C.c
@@ -3,7 +3,6 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 
 extern int fn_8011EB04(void *);
-#define fn_8011EB04(a) fn_8011EB04((void *)(a))
 extern u16 fn_8012A244(int value);
 extern int fn_801A9EF4(int minimum, int maximum);
 
@@ -14,7 +13,7 @@ extern float lbl_8064E3CC;
 
 u16 fn_8004998C(int value, u8* intensity, u32* flags)
 {
-    int type = fn_8011EB04(value);
+    int type = fn_8011EB04((void*)value);
     int state = fn_8012A244(value);
     u16 result = 0xFFFF;
     float scale = lbl_8064E3C0;
@@ -61,6 +60,7 @@ u16 fn_8004998C(int value, u8* intensity, u32* flags)
         case 17:
         case 18:
         case 19:
+        default:
             result = fn_801A9EF4(0x57, 0x5D);
             scale = lbl_8064E3C4;
             break;
@@ -89,6 +89,16 @@ u16 fn_8004998C(int value, u8* intensity, u32* flags)
         case 13:
             result = fn_801A9EF4(0x1A7, 0x1AB);
             break;
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
         default:
             result = fn_801A9EF4(0x1A4, 0x1A6);
             break;
@@ -147,6 +157,11 @@ u16 fn_8004998C(int value, u8* intensity, u32* flags)
         case 14:
             result = fn_801A9EF4(0x4F, 0x52);
             break;
+        case 15:
+        case 16:
+        case 17:
+        case 18:
+        case 19:
         default:
             result = fn_801A9EF4(0x1A4, 0x1A6);
             break;

--- a/src/game/game_fn_80068290.c
+++ b/src/game/game_fn_80068290.c
@@ -28,15 +28,15 @@ extern void fn_80201D1C(void *object, s32 value);
 
 s32 fn_80068290(void *object, s32 event, s32 *result)
 {
-    s32 state;
-    ObjectState *object_state;
+    RuntimeObject **installed;
+    void *state;
     s32 owner_id;
     unsigned char local[8];
 
-    state = (s32)fn_80201BC8(object);
-    object_state = fn_80201B8C(object);
+    state = fn_80201BC8(object);
+    installed = ((ObjectState *)fn_80201B8C(object))->installed;
     owner_id = fn_80201B54(object);
-    fn_8011F114(local, (void *)state);
+    fn_8011F114(local, state);
     fn_80200C20(event);
 
     if ((fn_80036D5C(object) & 0x80) != 0) {
@@ -46,9 +46,9 @@ s32 fn_80068290(void *object, s32 event, s32 *result)
         return 0;
     }
 
-    if (fn_80066D04(object, 0) != 0 && object_state->installed != 0 &&
-        *object_state->installed != 0 && (*object_state->installed)->active == 0) {
-        void *action = fn_801294DC((void *)state, 0x2B, 0x24, 10);
+    if (fn_80066D04(object, 0) != 0 && installed != 0 && *installed != 0 &&
+        (*installed)->active == 0) {
+        void *action = fn_801294DC(state, 0x2B, 0x24, 10);
         if (action != 0) {
             fn_80128C28(action, (void *)fn_800683E4, owner_id);
             fn_80067BAC(object);
@@ -59,6 +59,10 @@ s32 fn_80068290(void *object, s32 event, s32 *result)
             }
             return 1;
         }
+        if (result != 0) {
+            *result = 0;
+        }
+        return 0;
     }
 
     if (result != 0) {

--- a/src/game/game_fn_8006845C.c
+++ b/src/game/game_fn_8006845C.c
@@ -12,6 +12,10 @@ void fn_8006845C(void *object)
 
     objects = fn_800681C8();
     owner = fn_80201B54(object);
+    if (objects == 0) {
+        /* Debugger breakpoint retained from the original assertion guard. */
+        asm { nop }
+    }
 
     for (i = 0; i < 12; i++) {
         void *candidate;
@@ -22,18 +26,21 @@ void fn_8006845C(void *object)
             continue;
         }
         candidate = fn_80201814(objects[i]);
-        if (candidate == 0) {
-            objects[i] = 0;
-            continue;
-        }
-        owners = fn_800681C8();
-        if (owners == 0) {
-            continue;
-        }
-        for (j = 0; j < 12; j++) {
-            if (owners[j] == owner) {
-                owners[j] = 0;
+        if (candidate != 0) {
+            owners = fn_800681C8();
+            if (owners == 0) {
+                /* Debugger breakpoint retained from the original assertion guard. */
+                asm { nop }
             }
+            if (owners != 0) {
+                for (j = 0; j < 12; j++) {
+                    if (owners[j] == owner) {
+                        owners[j] = 0;
+                    }
+                }
+            }
+        } else {
+            objects[i] = 0;
         }
     }
 }

--- a/src/game/game_fn_8006EA4C.c
+++ b/src/game/game_fn_8006EA4C.c
@@ -30,41 +30,41 @@ extern const float lbl_8064E820;
 
 int fn_8006EA4C(Owner *owner)
 {
+    int id;
     int result;
     u8 index;
-    int id;
     void *resource;
     int i;
-    unsigned char *text;
     int value;
+    Callback callback;
+    void *argument;
 
     result = 0;
     resource = owner->resource;
     index = owner->index;
     id = *(unsigned int *)((unsigned char *)resource + 0x14) >> 16;
     fn_8006C9C0(resource);
-    if (id == owner->ids[index] && index < 4 && owner->callbacks[index] != 0 &&
-        owner->arguments[index] != 0) {
-        owner->callbacks[index](owner->arguments[index]);
-        fn_8006C9E4(resource, 0);
-        owner->last_index = index;
-        index++;
-        if (index >= 4) {
+    callback = owner->callbacks[index];
+    argument = owner->arguments[index];
+    if (id == owner->ids[index]) {
+        if (index < 4 && callback != 0 && argument != 0) {
+            callback(argument);
+            fn_8006C9E4(resource, 0);
+            owner->last_index = index;
+            index++;
+            if (index >= 4) {
+                result = 1;
+            }
+        } else {
             result = 1;
         }
-    } else {
-        result = 1;
     }
     owner->index = index;
 
     if (lbl_8064C8B0 != 0) {
-        text = lbl_80312888;
-        i = 0;
-        while (i < lbl_8064C8B4) {
-            value = lbl_802FC5BC[i].value;
-            fn_800EBA80(2, text, &value, 0x40, lbl_8064E820);
-            text += 0xC;
-            i++;
+        for (i = 0; i < lbl_8064C8B4; i++) {
+            value = lbl_802FC5BC->value;
+            fn_800EBA80(2, lbl_80312888 + i * 0xC, &value, 0x40, lbl_8064E820);
         }
     }
     return result;

--- a/src/game/game_fn_800723A8.c
+++ b/src/game/game_fn_800723A8.c
@@ -1,10 +1,3 @@
-/*
- * NonMatching: honest-C reconstruction of the resource-record file reader.
- * It opens the fixed resource archive, consumes its 0x20-byte header, checks
- * the requested 0xE0-byte record against the file-derived count, reads that
- * record with retry-on-negative-result semantics, and closes the file.
- */
-
 typedef struct FileHandle {
     char pad_00[0x34];
     unsigned int length;
@@ -23,26 +16,27 @@ extern void fn_8021345C(FileHandle *);
 int fn_800723A8(unsigned int index, void *output)
 {
     FileHandle file;
+    int result;
     unsigned int count;
     unsigned int offset;
-    int opened;
 
     fn_802136A4(&lbl_8064B540);
-    opened = fn_80213394(lbl_802446A0, &file);
+    result = fn_80213394(lbl_802446A0, &file);
     fn_802136A4(&lbl_8064B544);
-    if (opened == 0) {
-        return 0;
+    if (result != 0) {
+        count = (file.length - 0x20) / 0xE0;
+        offset = index * 0xE0 + 0x20;
+        while (fn_802137F4(&file, lbl_80244680, 0x20, 0, 2) < 0) {
+        }
+        if (index < count) {
+            int position = offset;
+            while (fn_802137F4(&file, output, 0xE0, position, 2) < 0) {
+            }
+            result = 1;
+            fn_8021345C(&file);
+        } else {
+            result = 0;
+        }
     }
-
-    count = (file.length - 0x20) / 0xE0;
-    offset = index * 0xE0 + 0x20;
-    while (fn_802137F4(&file, lbl_80244680, 0x20, 0, 2) < 0) {
-    }
-    if (index >= count) {
-        return 0;
-    }
-    while (fn_802137F4(&file, output, 0xE0, offset, 2) < 0) {
-    }
-    fn_8021345C(&file);
-    return 1;
+    return result;
 }

--- a/src/game/game_fn_80079AA4.c
+++ b/src/game/game_fn_80079AA4.c
@@ -5,16 +5,14 @@ extern void *fn_801A7498(void *object);
 extern void *fn_80201814();
 extern int fn_80128EAC(void *object);
 extern int fn_80201B5C(void *object);
-extern int fn_80204508(void *object, void *other);
+extern unsigned char fn_80204508(void *object, void *other);
 extern void fn_80064B38(void *object, int value, void *work);
 extern int fn_80079008(void *object, void *resource);
 extern int fn_80128F40(void *object);
-extern short fn_801A74F8(void *object);
+extern int fn_801A74F8(void *object);
 extern float fn_8010181C(float value);
 extern void fn_801A7518(void *object, int value);
 
-/* NonMatching: behavior-complete candidate validation, randomized temporary
- * value update, dispatch, and restoration. */
 void fn_80079AA4(void *object, void *resource, int value, void *work)
 {
     void *wrapper = (void *)fn_80200C38(value);
@@ -32,13 +30,24 @@ void fn_80079AA4(void *object, void *resource, int value, void *work)
             int state = fn_80079008(object, resource);
             int field = fn_80128F40(resource) >> 17;
 
-            if ((state == 0 || type == 0x7C || type == 0x81) &&
-                ((type != 0x7C && type != 0x81) || field == 10)) {
-                short original = fn_801A74F8(wrapper);
-                int randomized = (int)fn_8010181C((float)original * lbl_8064E938);
-                fn_801A7518(wrapper, randomized);
-                fn_80064B38(object, value, work);
-                fn_801A7518(wrapper, original);
+            if (state == 0 || type == 0x7C || type == 0x81) {
+                int allowed;
+
+                if (type == 0x7C) {
+                    allowed = field > 10;
+                } else if (type == 0x81) {
+                    allowed = field < 10;
+                } else {
+                    allowed = 1;
+                }
+                if (allowed) {
+                    int original = fn_801A74F8(wrapper);
+                    int randomized = (int)fn_8010181C((float)(short)original * lbl_8064E938);
+
+                    fn_801A7518(wrapper, randomized);
+                    fn_80064B38(object, value, work);
+                    fn_801A7518(wrapper, original);
+                }
             }
         }
     }

--- a/src/game/game_fn_80087A24.c
+++ b/src/game/game_fn_80087A24.c
@@ -9,15 +9,20 @@ typedef struct Owner {
     u16 value160;
 } Owner;
 
+typedef struct WorkEntry {
+    u8 mode;
+    u8 pad01;
+    u8 enabled_a;
+    u8 enabled_b;
+    u8 pad04[0x28];
+} WorkEntry;
+
 typedef struct Work {
     u8 pad18[0x18];
     u8 resource;
     u8 pad19[0x68 - 0x19];
-    u8 mode;
-    u8 pad69;
-    u8 enabled_a;
-    u8 enabled_b;
-    u8 pad6C[0xC4 - 0x6C];
+    WorkEntry entries[2];
+    u8 padC0[4];
     Owner* owner;
 } Work;
 
@@ -47,21 +52,21 @@ void fn_80087A24(Work* work)
 
     work->owner->state = 0;
     work->owner->value160 = 0;
-    ((u8*)work + index * 0x2C)[0x6A] = 1;
-    ((u8*)work + index * 0x2C)[0x6B] = 1;
-    ((u8*)work + index * 0x2C)[0x68] = 4;
+    work->entries[index].enabled_a = 1;
+    work->entries[index].enabled_b = 1;
+    work->entries[index].mode = 4;
     fn_8006DEF8(work, 6, fn_80087BA8, work, 1);
 
-    ((u8*)work + index * 0x2C)[0x68] = 0;
+    work->entries[index].mode = 0;
     fn_8006DEF8(work, 6, fn_80087D64, work, 1);
 
-    ((u8*)work + index * 0x2C)[0x68] = 1;
+    work->entries[index].mode = 1;
     fn_8006DEF8(work, 6, fn_80087EC4, work, 1);
 
-    ((u8*)work + index * 0x2C)[0x68] = 2;
+    work->entries[index].mode = 2;
     fn_8006DEF8(work, 6, fn_80088298, work, 1);
 
-    ((u8*)work + index * 0x2C)[0x68] = 0;
+    work->entries[index].mode = 0;
     lbl_8064C8C4 = 0;
     lbl_8064C91D = 3;
     fn_800FD40C(&work->resource, lbl_80245090);

--- a/src/game/game_fn_8008D6E4.c
+++ b/src/game/game_fn_8008D6E4.c
@@ -1,5 +1,7 @@
-typedef unsigned char u8;
 #pragma use_lmw_stmw on
+
+typedef unsigned char u8;
+typedef signed char s8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef struct Vec3 { float x, y, z; } Vec3;
@@ -21,9 +23,9 @@ typedef struct EffectD6E4 {
     u8 pad00;
     u8 enabled;
     u8 alpha;
-    u8 mode;
-    u16 type;
+    s8 mode;
     u16 duration;
+    u16 type;
     u8 pad08[0xE];
     u8 kind16;
     u8 kind17;
@@ -39,7 +41,9 @@ typedef struct EffectD6E4 {
     void (*callback)(void);
     u8 pad94[0x14];
     u32 owner;
-    u8 padAC[0x20];
+    u8 padAC[0x12];
+    u8 flag;
+    u8 padBF;
 } EffectD6E4;
 
 extern void* fn_80201B94();
@@ -47,9 +51,8 @@ extern int fn_80201C48(void*);
 extern int fn_80201B54();
 extern void *fn_80201814();
 extern void* fn_8015C2FC(int);
-#define FN_80201E78_RETURN void
-#define FN_80201E78_PARAMETERS Vec3*, void*
-extern FN_80201E78_RETURN fn_80201E78(FN_80201E78_PARAMETERS);extern unsigned int fn_80178E94(Vec3*, Vec3*);
+extern void fn_80201E78(Vec3*, void*);
+extern unsigned int fn_80178E94(Vec3*, Vec3*);
 extern int fn_800DE3F8(void);
 extern void fn_80140E58(void);
 extern u8 fn_80203F60(void*, void*, Vec3*, Vec3*, int);
@@ -71,104 +74,107 @@ extern void fn_8014F4CC(EffectD6E4*, void*);
 extern void fn_8019B13C(EffectD6E4*);
 extern int fn_801D3A24(void*, int);
 extern void* fn_80155DB4(void*);
-extern int fn_80148300(void*, EffectD6E4*, void*);
+extern void* fn_80148300(void*, EffectD6E4*, void*);
 extern void fn_80149EB8(void*);
 extern void fn_80201D2C(void *, int);
 extern void fn_80201D14(void *, int);
 extern void fn_8012B344(void*);
-extern float lbl_8064EFA4;
-extern float lbl_8064EFA8;
-extern u32 lbl_8064A80C;
+extern float lbl_8064EC10;
+extern float lbl_8064EC24;
+extern const float lbl_8064EC28;
+extern u32 lbl_8064D18C;
 
-/* NonMatching: behavior-complete frontier reconstruction; aggregate layout and
- * declaration-sensitive register allocation remain to be refined. */
 int fn_8008D6E4(void* object, void* resource)
 {
-    Vec3 target_position, object_position, delta, spawn_position;
+    Vec3 spawn_position;
+    Vec3 delta;
+    Vec3 target_position;
+    Vec3 object_position;
     EffectD6E4 effect;
     int pair[2];
     void* runtime_object;
+    void* target;
     int object_id;
     int target_id;
-    void* target;
-    void* collision;
     unsigned int distance;
     void* created;
     RuntimeD6E4* runtime;
     ValuesD6E4* values;
+    void* collision;
     void* attachment;
-    void* spawned;
     void* manager;
+    void* spawned;
 
     runtime_object = fn_80201B94(object);
     object_id = fn_80201C48(runtime_object);
     target_id = fn_80201B54(object);
     target = fn_80201814(object_id);
-    if (target == 0) return 0;
-    collision = fn_8015C2FC(2);
-    fn_80201E78(&target_position, target);
-    spawn_position = target_position;
-    fn_80201E78(&object_position, object);
-    delta = object_position;
-    distance = fn_80178E94(&delta, &spawn_position);
-    if (object_id != fn_800DE3F8()) {
-        if (distance >= 500) return 0;
-        fn_80140E58();
-        if (fn_80203F60(resource, collision, &delta, &spawn_position, 0)) return 0;
-    }
-    created = fn_801294DC(resource, 139, 32, 6);
-    if (created == 0) return 0;
-    fn_80201E78(&delta, object);
-    delta.z += lbl_8064EFA4;
-    if ((u32)fn_8020123C(125, target_id, object_id, 0) != 1) {
-        fn_8012B344(resource);
-        return 0;
-    }
-    runtime = ((RuntimeD6E4*)fn_80201B8C(object));
-    values = (ValuesD6E4*)runtime->values;
-    if (fn_800DEA28(target)) {
-        values->second = object_id;
-        values->first = 0;
-    } else {
-        values->first = object_id;
-        values->second = 0;
-    }
-    fn_80128C28(created, fn_80204810, (target_id << 8) | 6);
-    attachment = fn_80201BC8(object);
-    fn_8011FA8C(attachment, 0, 0x20000000);
-    fn_8011FABC(attachment, 0, 1);
-    pair[0] = pair[1] = fn_801D3974(runtime->effect_source);
-    fn_8011FF24(pair);
-    fn_801AAE68(lbl_8064EFA8, 497, 100, 0, &delta, 2, 2, 0,
-                (u16)lbl_8064A80C, 0);
-    spawned = fn_80149E04();
-    if (spawned != 0) {
-        fn_80147E88(&effect);
-        fn_8014F4CC(&effect, spawned);
-        effect.owner = target_id;
-        ((int*)spawned)[2] = 0;
-        ((int*)spawned)[18] = 0;
-        fn_8019B13C(&effect);
-        effect.enabled = 6;
-        effect.type = 45;
-        effect.duration = fn_801D3A24(runtime->effect_source, 49);
-        effect.alpha = 160;
-        effect.mode = 0xFE;
-        effect.value1C = 0;
-        effect.value20 = 0;
-        effect.kind16 = 5;
-        effect.kind17 = 160;
-        effect.scale = lbl_8064EFA4;
-        manager = fn_80155DB4(object);
-        if (manager != 0) {
-            effect.pad00 = 0x80;
-            if (fn_80148300(manager, &effect, spawned) == 0)
-                fn_80149EB8(spawned);
-        } else {
-            fn_80149EB8(spawned);
+    if (target != 0) {
+        collision = fn_8015C2FC(2);
+        fn_80201E78(&target_position, target);
+        spawn_position = target_position;
+        fn_80201E78(&object_position, object);
+        delta = object_position;
+        distance = fn_80178E94(&delta, &spawn_position);
+        /* Refresh collision state immediately before probing the path. */
+        if (object_id == fn_800DE3F8() ||
+            (distance < 500 && (fn_80140E58(), fn_80203F60(resource, collision, &delta, &spawn_position, 0) == 0))) {
+            created = fn_801294DC(resource, 139, 32, 6);
+            if (created != 0) {
+                fn_80201E78(&delta, object);
+                delta.z += lbl_8064EC24;
+                if ((u32)(fn_8020123C(125, target_id, object_id, 0) & 0xFFFFFFFF) == 1) {
+                runtime = ((RuntimeD6E4*)fn_80201B8C(object));
+                values = (ValuesD6E4*)runtime->values;
+                if (fn_800DEA28(target)) {
+                    values->second = object_id;
+                    values->first = 0;
+                } else {
+                    values->first = object_id;
+                    values->second = 0;
+                }
+                fn_80128C28(created, fn_80204810, (target_id << 8) | 6);
+                attachment = fn_80201BC8(object);
+                fn_8011FA8C(attachment, 0, 0x20000000);
+                fn_8011FABC(attachment, 0, 1);
+                pair[0] = pair[1] = fn_801D3974(runtime->effect_source);
+                fn_8011FF24(pair);
+                fn_801AAE68(lbl_8064EC28, 497, 100, 0, &delta, 2, 2, 0,
+                            (u16)lbl_8064D18C, 0);
+                spawned = fn_80149E04();
+                if (spawned != 0) {
+                    fn_80147E88(&effect);
+                    fn_8014F4CC(&effect, spawned);
+                    effect.owner = target_id;
+                    ((int*)spawned)[2] = 0;
+                    ((int*)spawned)[18] = 0;
+                    fn_8019B13C(&effect);
+                    effect.enabled = 6;
+                    effect.type = 45;
+                    effect.duration = fn_801D3A24(runtime->effect_source, 49);
+                    effect.alpha = 160;
+                    effect.mode = -2;
+                    effect.value1C = 0;
+                    effect.value20 = 0;
+                    effect.kind16 = 5;
+                    effect.kind17 = 160;
+                    effect.scale = lbl_8064EC10;
+                    manager = fn_80155DB4(object);
+                    if (manager != 0) {
+                        effect.flag = 0x80;
+                        if (fn_80148300(manager, &effect, spawned) == 0)
+                            fn_80149EB8(spawned);
+                    } else {
+                        fn_80149EB8(spawned);
+                    }
+                }
+                fn_80201D2C(object, 59);
+                fn_80201D14(object, 1);
+                return 1;
+                }
+                fn_8012B344(resource);
+            }
         }
     }
-    fn_80201D2C(object, 59);
-    fn_80201D14(object, 1);
-    return 1;
+    return 0;
 }

--- a/src/game/game_fn_8008D9F4.c
+++ b/src/game/game_fn_8008D9F4.c
@@ -8,7 +8,7 @@ typedef struct RuntimeD9F4 {
 } RuntimeD9F4;
 
 extern void* lbl_8064C4E4;
-extern int lbl_8064A80C;
+extern int lbl_8064D18C;
 extern Vec3 lbl_8023963C;
 extern void *fn_80201B9C();
 extern void fn_8011F114();
@@ -20,48 +20,49 @@ extern unsigned int fn_80178E94(Vec3*, Vec3*);
 extern unsigned long long fn_8020123C();
 extern void* fn_80201BC0(void*);
 
-int fn_8008D9F4(void* object, void* unused4, void* unused5, int flags)
+int fn_8008D9F4(void* object, void* unused4, void* unused5, u8 flags)
 {
-    Vec3 base;
-    Vec3 initial;
-    Vec3 candidate;
-    Vec3 fallback;
     void* current;
+    Vec3 base;
+    Vec3 candidate;
+    Vec3 initial;
+    Vec3 fallback;
+    unsigned int best_distance;
     int own_id;
-    int best_distance = 0;
-    int best_id = 0;
-    int allow_a = flags & 1;
-    int allow_b = flags & 2;
+    int best_id;
 
     current = fn_80201B9C(object);
     fn_8011F114(&initial, lbl_8064C4E4);
     base = initial;
+    best_distance = 0;
+    best_id = 0;
     own_id = fn_80201B54(object);
     while (current != 0) {
         RuntimeD9F4* runtime = ((RuntimeD9F4*)fn_80201B8C(current));
         void* attachment = fn_80201BC8(current);
+        Vec3 constant;
         Vec3* selected;
         int candidate_id;
-        int distance;
+        unsigned int distance;
         int target_id;
 
         if (attachment != 0) {
             fn_8011F114(&fallback, attachment);
             selected = &fallback;
         } else {
-            fallback = lbl_8023963C;
-            selected = &fallback;
+            constant = lbl_8023963C;
+            selected = &constant;
         }
         candidate = *selected;
         candidate_id = fn_80201EB8(current);
         target_id = fn_80201B54(current);
         distance = fn_80178E94(&base, &candidate) + 1;
-        if (candidate_id == lbl_8064A80C && runtime != 0 &&
-            ((allow_a && runtime->type9f == 10) ||
-             (allow_b && runtime->type9f == 24) ||
-             (allow_b && runtime->flag9e == 1)) &&
+        if (candidate_id == lbl_8064D18C && runtime != 0 &&
+            (((flags & 1) && runtime->type9f == 10) ||
+             ((flags & 2) && runtime->type9f == 24) ||
+             ((flags & 2) && runtime->flag9e == 1)) &&
             attachment != 0 && distance > best_distance &&
-            (unsigned int)fn_8020123C(125, own_id, target_id, 0) == 1) {
+            (unsigned int)(fn_8020123C(125, own_id, target_id, 0) & 0xFFFFFFFF) == 1) {
             best_distance = distance;
             best_id = target_id;
         }

--- a/src/game/game_fn_8008E110.c
+++ b/src/game/game_fn_8008E110.c
@@ -18,8 +18,6 @@ extern void fn_80201D2C(void *, int);
 extern void fn_80201D14(void *, int);
 extern int fn_8008E078(void*, void*, void*);
 
-/* NonMatching: behavior-complete frontier reconstruction; remaining differences
- * are declaration/control-expression register allocation around two tests. */
 int fn_8008E110(void* object, void* resource, void* argument,
                 Data8008E110* data)
 {
@@ -29,12 +27,7 @@ int fn_8008E110(void* object, void* resource, void* argument,
     int object_id;
     void* spawned;
 
-    selected = data->primary;
-    if (selected == 0) goto use_fallback;
-    goto selected_ready;
-use_fallback:
-    selected = data->fallback;
-selected_ready:
+    selected = data->primary != 0 ? data->primary : data->fallback;
     object_id = fn_80201B54(object);
     loaded = fn_80201814(selected);
     if (loaded != 0) {
@@ -42,8 +35,9 @@ selected_ready:
     }
     if (loaded != 0 && created != 0) {
         u64 state = fn_8020123C(125, object_id, selected, 1);
-        if ((unsigned int)state == 1) {
-            if (fn_800DE3F8() == selected) {
+        if ((unsigned int)(state & 0xFFFFFFFF) == 1) {
+            int current = fn_800DE3F8();
+            if (current == selected) {
                 spawned = fn_800CCF60(loaded, 0, 0, object, 0, 0, 0, 0, 10,
                                       20, 0);
             } else {

--- a/src/game/game_fn_8008E294.c
+++ b/src/game/game_fn_8008E294.c
@@ -11,9 +11,8 @@ typedef struct Data8008E294 {
 extern void* fn_8015C2FC(int);
 extern int fn_80036D5C(void*);
 extern void *fn_80201814();
-#define FN_80201E78_RETURN void
-#define FN_80201E78_PARAMETERS Vec3*, void*
-extern FN_80201E78_RETURN fn_80201E78(FN_80201E78_PARAMETERS);extern const float lbl_80239654[3];
+extern void fn_80201E78(Vec3*, void*);
+extern const Vec3 lbl_80239654;
 extern u32 fn_80178E94(Vec3*, Vec3*);
 extern int fn_800DE3F8(void);
 extern void fn_80140E58(void);
@@ -21,37 +20,36 @@ extern u8 fn_80203F60(void*, void*, Vec3*, Vec3*, int);
 extern int fn_8008E110(void*, void*, void*, Data8008E294*);
 extern int fn_8008E078(void*, void*, void*);
 
-/* NonMatching: behavior-complete frontier reconstruction; stack-local lifetime
- * and compound-condition codegen remain to be refined. */
 int fn_8008E294(void* object, Data8008E294* data, void* resource,
                 Vec3* position, void* argument)
 {
-    void* manager = fn_8015C2FC(2);
-    int selected = data->primary;
-    int flags;
     void* loaded;
+    void* manager = fn_8015C2FC(2);
+    u32 flags;
+    int selected;
     Vec3 target;
+    Vec3 loaded_target;
+    Vec3 constant;
+    Vec3* chosen;
     u32 distance;
 
-    if (selected == 0) {
-        selected = data->fallback;
-    }
+    selected = data->primary != 0 ? data->primary : data->fallback;
     flags = fn_80036D5C(object) & 0x00100000;
     loaded = fn_80201814(selected);
     if (loaded != 0) {
-        fn_80201E78(&target, loaded);
+        fn_80201E78(&loaded_target, loaded);
+        chosen = &loaded_target;
     } else {
-        target.x = lbl_80239654[0];
-        target.y = lbl_80239654[1];
-        target.z = lbl_80239654[2];
+        constant = lbl_80239654;
+        chosen = &constant;
     }
+    target = *chosen;
     distance = fn_80178E94(position, &target);
-    if (loaded != 0 && flags == 0 && selected != fn_800DE3F8() &&
-        distance < 500) {
-        fn_80140E58();
-        if (fn_80203F60(resource, manager, position, &target, 0) == 0) {
-            return fn_8008E110(object, resource, argument, data);
-        }
+    /* Refresh collision state immediately before probing the path. */
+    if (loaded != 0 &&
+        (flags != 0 || selected == fn_800DE3F8() ||
+         (distance < 500 && (fn_80140E58(), fn_80203F60(resource, manager, position, &target, 0) == 0)))) {
+        return fn_8008E110(object, resource, argument, data);
     }
     return fn_8008E078(object, resource, argument);
 }

--- a/src/game/game_fn_8008F224.c
+++ b/src/game/game_fn_8008F224.c
@@ -22,6 +22,7 @@ typedef struct SpawnConfig {
     int pad1;
     int value2;
     int mode;
+    int pad2[4];
 } SpawnConfig;
 
 extern float lbl_8064EC10;
@@ -35,8 +36,7 @@ extern int fn_80201B54();
 extern unsigned long long fn_8020123C();
 extern void* fn_80201BC0(void*);
 extern void fn_80043F44(SpawnConfig*);
-extern unsigned int fn_800FBFB0(void);
-#define fn_800FBFB0() ((int)fn_800FBFB0())
+extern int fn_800FBFB0(void);
 extern void* fn_80034708(SpawnConfig*);
 extern void *fn_80201BC8();
 extern void fn_80201D54(void*, void*);
@@ -54,26 +54,28 @@ extern void fn_80038544(void*, int, short);
 extern void fn_8011F0E8(void*, Vec3*);
 extern void fn_80048708(void*);
 
-void* fn_8008F224(void* object, int create, int transfer)
+void* fn_8008F224(int object_id, int create, int transfer)
 {
+    void* found;
     void* current;
-    void* found = 0;
-    void* owner = 0;
-    void* source_owner;
+    void* owner;
     Vec3 position;
     short value;
+    void* source_owner;
 
-    current = fn_80201B9C(object);
+    current = fn_80201B9C((void*)object_id);
+    found = 0;
+    owner = 0;
     source_owner = ((void*)fn_80201B44());
-    fn_800DE8FC(object, &position);
+    fn_800DE8FC((void*)object_id, &position);
     while (current != 0 && found == 0) {
         Runtime* runtime = ((Runtime*)fn_80201B8C(current));
         if (runtime != 0) {
-            void* candidate = (void *)fn_80201EB8(current);
+            int candidate = fn_80201EB8(current);
             void* candidate_owner = ((void*)fn_80201B54(current));
-            if (candidate == object && runtime->type == 2 &&
+            if (candidate == object_id && runtime->type == 2 &&
                 runtime->subtype == 10 &&
-                (int)fn_8020123C(59, 0, candidate_owner, 0) != 0) {
+                (int)(fn_8020123C(59, 0, candidate_owner, 0) & 0xFFFFFFFF) != 0) {
                 found = current;
             }
         }
@@ -83,51 +85,53 @@ void* fn_8008F224(void* object, int create, int transfer)
     if (found == 0) {
         if (create != 0) {
             SpawnConfig config;
-            void* spawned;
             void* state;
+            void* spawned;
             Runtime* runtime;
             int flags;
             unsigned int index;
+            int* data;
 
             fn_80043F44(&config);
-            config.position = position;
-            config.scale = lbl_8064EC10;
+            index = (unsigned int)object_id - 0xF1;
             config.kind = 68;
+            config.scale = lbl_8064EC10;
             config.mode = 44;
-            index = (unsigned int)object - 0xF1;
+            config.position = position;
             switch (index) {
-            case 0:
+            case 6:
                 config.value0 = 106;
-                config.value1 = 0x816;
-                config.value2 = 0x2D4;
+                config.value1 = 0x817;
+                config.value2 = 0x2A9;
+                break;
+            case 5:
+                config.value0 = 106;
+                config.value1 = 0x8BA;
+                config.value2 = 0x2D6;
                 break;
             case 1:
                 config.value0 = 105;
                 config.value1 = 0x819;
                 config.value2 = 0x2D9;
                 break;
-            case 3:
-                config.value0 = 106;
-                config.value1 = 0x818;
-                config.value2 = 0x2D5;
-                break;
             case 4: {
                 int alternate;
                 config.value0 = (fn_800FBFB0() & 1) + 105;
                 alternate = config.value0 == 106;
+                alternate = alternate != 0;
                 config.value1 = alternate + 0x7FB;
                 config.value2 = alternate + 0x2D7;
                 break;
             }
-            case 5:
+            case 0:
                 config.value0 = 106;
-                config.value1 = 0x8BA;
-                config.value2 = 0x2D6;
+                config.value1 = 0x816;
+                config.value2 = 0x2D4;
                 break;
-            case 6:
+            case 3:
                 config.value0 = 106;
-                config.value1 = 0x817;
-                config.value2 = 0x2A9;
+                config.value1 = 0x818;
+                config.value2 = 0x2D5;
                 break;
             default:
                 config.value0 = 106;
@@ -137,7 +141,7 @@ void* fn_8008F224(void* object, int create, int transfer)
             spawned = fn_80034708(&config);
             fn_80201BC8();
             owner = ((void*)fn_80201B54(spawned));
-            fn_80201D54(spawned, object);
+            fn_80201D54(spawned, (void*)object_id);
             fn_802015A4(spawned);
             fn_800CCA44(spawned);
             state = fn_80201B94(spawned);
@@ -145,13 +149,14 @@ void* fn_8008F224(void* object, int create, int transfer)
             fn_80201DD8(state, source_owner);
             fn_80201E60(state, flags | 1);
             runtime = ((Runtime*)fn_80201B8C(spawned));
-            runtime->data[1] = 0xAD7;
-            fn_801E8328(1, spawned, runtime->data);
+            data = runtime->data;
+            data[1] = 0xAD7;
+            fn_801E8328(1, spawned, data);
         }
     } else {
         owner = ((void*)fn_80201B54(found));
         if (transfer != 0) {
-            void* actor = fn_80201BC8();
+            void* actor = fn_80201BC8(found);
             fn_80038464(found, 0, &value);
             fn_800389E0(found, 0, value, 0);
             fn_800386FC(owner, 0, &value);

--- a/src/game/game_fn_800A3104.c
+++ b/src/game/game_fn_800A3104.c
@@ -8,15 +8,9 @@ typedef struct Object800A3104 {
 
 extern int fn_800A30C0(Object800A3104*);
 
-/*
- * Behavior-complete reconstruction. The retail TU inlined fn_800A30AC here
- * and retained its result in r0 before moving it to r31. With this function
- * split into an independent TU, MWCC coalesces that value directly into r31,
- * leaving the generated body four bytes shorter.
- */
 int fn_800A3104(Object800A3104* object, int enabled)
 {
-    u16 old_value = object->flags & 1;
+    int old_value = (u16)(object->flags & 1);
 
     if (fn_800A30C0(object) == 0) {
         if (enabled != 0) {

--- a/src/game/game_fn_800AAD14.c
+++ b/src/game/game_fn_800AAD14.c
@@ -16,9 +16,6 @@ typedef struct ObjectState {
     EffectState* effect;
 } ObjectState;
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define NONNEG(a) ((a) & (((-(a)) & ~(a)) >> 31))
-
 extern int fn_80201B54();
 extern void *fn_80201B8C();
 extern unsigned long long fn_8020123C();
@@ -26,6 +23,8 @@ extern Vec3i* fn_8011F130(void*);
 extern int* lbl_8064C5A8;
 extern int lbl_8023BA20[];
 extern void fn_800AA7F0(EffectState*, Vec3i*, int*, int, int, int);
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 int fn_800AAD14(void* object, void* position)
 {
@@ -44,12 +43,11 @@ int fn_800AAD14(void* object, void* position)
     if (effect->active == 1 && effect->dispatched == 0) {
         Vec3i* point = fn_8011F130(position);
         int value = *lbl_8064C5A8 - 1;
-        int mask = -value & ~value;
-        int color = value & (mask >> 31);
-        if (color > 2) {
+        int color;
+        if (MAX(value, 0) > 2) {
             color = 2;
         } else {
-            color = value & (mask >> 31);
+            color = MAX(value, 0);
         }
         fn_800AA7F0(effect, point, &lbl_8023BA20[color], 600, 0, owner);
         effect->dispatched = 1;

--- a/src/game/game_fn_800AF230.c
+++ b/src/game/game_fn_800AF230.c
@@ -5,11 +5,11 @@ extern void fn_801B05B0(int, int);
 
 void fn_800AF230(void)
 {
-    int ids[4] = { 0, 1, 2, 4 };
-    int i;
-    int handle;
-
     if (fn_80070E30() == 0) {
+        int ids[4] = { 0, 1, 2, 4 };
+        int i;
+        int handle;
+
         for (i = 0; i < 4; i++) {
             handle = fn_800AE88C(ids[i]);
             if (fn_801AF824(handle) != 0) {

--- a/src/game/game_fn_800B002C.c
+++ b/src/game/game_fn_800B002C.c
@@ -35,6 +35,7 @@ int fn_800B002C(void)
     unsigned char* buffer = lbl_8031F7C0;
     void* current;
     int oldValue;
+    int offset;
     void* object;
     Vec3 position;
     float scale;
@@ -50,8 +51,8 @@ int fn_800B002C(void)
         fn_8012B7A0(object, scale);
         memcpy(&value, buffer + 16, 4);
         fn_8011FB54(object, value);
-        object = (void*)(fn_800E507C(buffer + 20) + 20);
-        object = (void*)((u32)object + fn_801F4E94(buffer + (u16)(u32)object));
+        offset = fn_800E507C(buffer + 20) + 20;
+        offset += fn_801F4E94(buffer + (u16)offset);
         oldValue = lbl_8064D18C;
         if (oldValue != value) {
             lbl_8064CDC4 = 0;
@@ -60,15 +61,15 @@ int fn_800B002C(void)
         if (value != oldValue) {
             fn_80200EAC(lbl_8064F010, 62, 0, 0, value);
         }
-        object = (void*)((u32)object + fn_80028E0C(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_8016B21C(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801FAD4C(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801F6794(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_8012BB34(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801E9068(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_801A8268(buffer + (u16)(u32)object));
-        object = (void*)((u32)object + fn_8011E98C(buffer + (u16)(u32)object));
-        fn_801A9A20(buffer + (u16)(u32)object);
+        offset += fn_80028E0C(buffer + (u16)offset);
+        offset += fn_8016B21C(buffer + (u16)offset);
+        offset += fn_801FAD4C(buffer + (u16)offset);
+        offset += fn_801F6794(buffer + (u16)offset);
+        offset += fn_8012BB34(buffer + (u16)offset);
+        offset += fn_801E9068(buffer + (u16)offset);
+        offset += fn_801A8268(buffer + (u16)offset);
+        offset += fn_8011E98C(buffer + (u16)offset);
+        fn_801A9A20(buffer + (u16)offset);
         return 1;
     }
     return 0;

--- a/src/game/game_fn_800B84DC.c
+++ b/src/game/game_fn_800B84DC.c
@@ -5,7 +5,7 @@ extern int lbl_8064CDC8;
 extern int lbl_8064C2C4;
 extern float lbl_8064F070;
 extern float lbl_8064F01C;
-extern s16 fn_800B8F38(void);
+extern int fn_800B8F38(void);
 extern int fn_8017BB60(void);
 extern int fn_80220234(int, int *, int *);
 extern int fn_800B194C(void);
@@ -13,26 +13,27 @@ extern int fn_801E6350(void *);
 extern int fn_801E6380(void *);
 extern int fn_801E63F0(void *);
 extern int fn_801E6420(void *);
-extern void fn_801A8974(int, int, int, int, int, int);
-extern void fn_801A872C(int, int, int, int, int, int, int *);
+extern void fn_801A8974(int, s16, s16, s16, int, int);
+extern void fn_801A872C(int, s16, s16, s16, int, int, int*);
 extern void fn_801ED5F4(int, int, int, int, int, float);
 
 void fn_800B84DC(void)
 {
-    s16 fourth;
     s16 third;
+    s16 fourth;
     int first;
     s16 second;
+    int index;
     int output1;
     int output2;
 
-    third = fn_800B8F38();
+    index = fn_800B8F38();
     if (fn_8017BB60() == 0) {
         fn_80220234(0, &output1, &output2);
         fn_80220234(1, &output1, &output2);
     }
     if (fn_800B194C() == 12) {
-        if (third == 0) {
+        if (index == 0) {
             second = 334;
             third = 227;
             fourth = 44;
@@ -44,10 +45,10 @@ void fn_800B84DC(void)
             first = 184;
         }
     } else {
-        first = fn_801E6350(lbl_80320B48[third]);
-        second = fn_801E6380(lbl_80320B48[third]) + 8;
-        third = fn_801E63F0(lbl_80320B48[third]) + 7;
-        fourth = fn_801E6420(lbl_80320B48[third]) - 6;
+        first = fn_801E6350(lbl_80320B48[index]);
+        second = fn_801E6380(lbl_80320B48[index]) + 8;
+        third = fn_801E63F0(lbl_80320B48[index]) + 7;
+        fourth = fn_801E6420(lbl_80320B48[index]) - 6;
     }
     if (lbl_8064CDC8 == 3) {
         fn_801A8974(first, second, third, fourth, -1, 3);

--- a/src/game/game_fn_800C1D60.c
+++ b/src/game/game_fn_800C1D60.c
@@ -26,50 +26,56 @@ extern void fn_8012B344(void*);
 
 int fn_800C1D60(void *object, void *event)
 {
+    void *event_object;
     int handled = 0;
-    void *event_object = fn_80201814(fn_801A7498(event));
     void **state;
     u8 *runtime;
-    u32 flags;
+    u8 *obj = object;
     u32 mode;
+    u32 flags;
+    u32 result;
     int delta;
 
+    event_object = fn_80201814(fn_801A7498(event));
     fn_80201B54(event_object);
     state = ((void **)fn_80201B8C(event_object));
     runtime = (u8 *)state[0];
-    flags = fn_8003BD48(object, event);
-    mode = fn_80128EE4(object);
+    flags = fn_8003BD48(obj, event);
+    mode = fn_80128EE4(obj);
     if ((flags & 3) != 0) {
         lbl_8064CA8C = flags;
     }
 
     if ((mode & 0x20) != 0) {
-        int value = fn_80128F40(object);
-        delta = fn_8012A1BC(object, fn_80128EAC(object)) - (value >> 17);
+        int value = fn_80128F40(obj);
+        delta = fn_8012A1BC(obj, fn_80128EAC(obj)) - (value >> 17);
 
         if ((flags & 0x20) != 0) {
-            void *owner = fn_8011F130(object);
+            void *owner = fn_8011F130(obj);
             if ((flags & 8) != 0) {
-                fn_80128B10(object, 20);
+                fn_80128B10(obj, 20);
             } else {
-                fn_80128B10(object, 7);
+                fn_80128B10(obj, 7);
                 fn_801AC9F4(41, 100, owner, 2);
             }
-            fn_80128F74(object, fn_801290D0(object) | 0x200);
+            result = fn_801290D0(obj);
+            fn_80128F74(obj, result | 0x200);
             handled = 1;
         } else if ((flags & 0x10) != 0) {
             u8 sound;
-            void *owner = fn_8011F130(object);
+            void *owner = fn_8011F130(obj);
             fn_801AC9F4(fn_80050B08(-2, fn_80050950(), 28, &sound, 0, 0, 0),
                          (int)sound, owner, 2);
             fn_80204028(event_object, 10000, 0, 0);
-            fn_80128B10(object, 4);
-            fn_80128F74(object, fn_801290D0(object) | 0x200);
+            fn_80128B10(obj, 4);
+            result = fn_801290D0(obj);
+            fn_80128F74(obj, result | 0x200);
             handled = 1;
         } else if ((flags & 0x40) != 0) {
-            fn_801AC9F4(714, 100, fn_8011F130(object), 2);
+            void *owner = fn_8011F130(obj);
             handled = 1;
-            fn_8012B344(object);
+            fn_801AC9F4(714, 100, owner, 2);
+            fn_8012B344(obj);
         }
     }
 

--- a/src/game/game_fn_800DFD54.c
+++ b/src/game/game_fn_800DFD54.c
@@ -1,26 +1,32 @@
 typedef unsigned char u8;
+typedef signed char s8;
 
 typedef struct Payload {
     u8 bytes[4];
 } Payload;
 
+typedef struct Delta {
+    s8 bytes[4];
+} Delta;
+
 #pragma use_lmw_stmw on
 
-extern int lbl_8064B80C;
+extern int lbl_8064D18C;
 extern int fn_80201B54();
 extern int fn_8011FB4C(void *);
 extern int fn_80200C38();
 extern unsigned short fn_8012DBE8(void *, int, Payload *);
 extern int fn_800DE298(void *);
-extern void* fn_8012C62C(void *, int, Payload *, Payload *, Payload *, int);
+extern void* fn_8012C62C(void *, int, Payload, Delta, Payload, int);
 
 void fn_800DFD54(int enabled, void *object, void *resource, void *event)
 {
+    Delta second;
     Payload source;
     Payload first;
-    Payload second = {{0, 0, 0, 0}};
     int type;
     int flag;
+    int ready;
 
     fn_80201B54(object);
     type = fn_8011FB4C(resource);
@@ -29,16 +35,20 @@ void fn_800DFD54(int enabled, void *object, void *resource, void *event)
     first.bytes[0] = source.bytes[0];
     first.bytes[1] = source.bytes[1];
     first.bytes[2] = source.bytes[2];
+    second.bytes[0] = second.bytes[1] = second.bytes[2] = 0;
 
-    if (type == lbl_8064B80C && fn_800DE298(object) != 0) {
+    if (type == lbl_8064D18C) {
+        ready = fn_800DE298(object);
         if (flag != 0) {
-            source.bytes[3] = 0xFB;
-            second.bytes[3] = 5;
-            fn_8012C62C(resource, 15, &source, &second, &first, 4);
-        } else if (enabled != 0) {
-            source.bytes[3] = 0;
-            second.bytes[3] = (u8)-5;
-            fn_8012C62C(resource, 15, &source, &second, &first, 4);
+            if (ready != 0) {
+                second.bytes[3] = 5;
+                first.bytes[3] = 0xFB;
+                fn_8012C62C(resource, 15, source, second, first, 4);
+            }
+        } else if (ready != 0 && enabled != 0) {
+            second.bytes[3] = -5;
+            first.bytes[3] = 0;
+            fn_8012C62C(resource, 15, source, second, first, 4);
         }
     }
 }

--- a/src/game/game_fn_8011F140.c
+++ b/src/game/game_fn_8011F140.c
@@ -8,20 +8,34 @@ typedef struct TransformData {
     float direction[3];
 } TransformData;
 
-/* Honest reconstruction; paired-single u16 conversion remains unmatched. */
+extern const float lbl_80650080;
+extern const float lbl_80650084;
+extern const float lbl_80650068;
+extern const float lbl_8065006C;
+
 void fn_8011F140(void* object, int index, TransformData* output)
 {
     u8* owner = *(u8**)((u8*)object + 60);
     u8* record = *(u8**)(owner + 188) + index * 28;
+    register float* direction = output->direction;
+    register u8* source = record + 14;
+    float scaled;
 
-    output->position[0] = (float)*(s16*)(record + 8) * 4.0f * 0.0625f;
-    output->position[1] = (float)*(s16*)(record + 10) * 4.0f * 0.0625f;
-    output->position[2] = (float)*(s16*)(record + 12) * 4.0f * 0.0625f;
-    output->direction[0] = (float)*(u16*)(record + 14);
-    output->direction[1] = (float)*(u16*)(record + 16);
-    output->direction[2] = (float)*(u16*)(record + 18);
-    if (output->direction[0] == 0.0f && output->direction[1] == 0.0f &&
-        output->direction[2] == 0.0f) {
-        output->direction[1] = 1.0f;
+    scaled = lbl_80650080 * (float)*(s16*)(record + 8);
+    output->position[0] = scaled * lbl_80650084;
+    scaled = lbl_80650080 * (float)*(s16*)(record + 10);
+    output->position[1] = scaled * lbl_80650084;
+    scaled = lbl_80650080 * (float)*(s16*)(record + 12);
+    output->position[2] = scaled * lbl_80650084;
+    /* Convert the packed u16 direction through the configured GQRs. */
+    asm {
+        psq_l f0, 0(source), 0, 7
+        psq_lu f1, 4(source), 1, 7
+        psq_st f0, 0(direction), 0, 0
+        psq_stu f1, 8(direction), 1, 0
+    }
+    if (lbl_80650068 == output->direction[0] && lbl_80650068 == output->direction[1] &&
+        lbl_80650068 == output->direction[2]) {
+        output->direction[1] = lbl_8065006C;
     }
 }

--- a/src/game/game_fn_8011F41C.c
+++ b/src/game/game_fn_8011F41C.c
@@ -8,7 +8,12 @@ extern void fn_802114B8(Matrix output, float x, float y, float z);
 extern void fn_802114E0(Matrix output, void* angles);
 extern void fn_80210FDC(Matrix left, Matrix right, Matrix output);
 
-/* Honest reconstruction; exact MWCC stack-slot and register scheduling remains. */
+typedef struct Vec3 {
+    float x;
+    float y;
+    float z;
+} Vec3;
+
 void fn_8011F41C(void* object, int index, int use_linked_index, Matrix output,
                  int apply_object_transform, int apply_record_rotation)
 {
@@ -17,33 +22,33 @@ void fn_8011F41C(void* object, int index, int use_linked_index, Matrix output,
     u8* records = *(u8**)(owner + 0x24);
     u8* record = records + index * 0x50;
     Matrix record_transform;
+    Matrix translation;
+    Matrix rotation;
+    Matrix linked_translation;
+    int resolved = index;
 
     if (object == *(void**)(bytes + 0x174) && use_linked_index) {
-        index = (*(u8**)(record + 0x3C) - records) / 0x50;
+        resolved = (*(u8**)(record + 0x3C) - records) / 0x50;
     }
-    fn_80127DF8(object, index, output);
+    fn_80127DF8(object, resolved, output);
 
     if (object == *(void**)(bytes + 0x174) && use_linked_index) {
-        u8* position = *(u8**)(bytes + 0x154) + index * 12;
-        Matrix translation;
-        fn_80211484(translation, *(float*)(position + 0),
-                    *(float*)(position + 4), *(float*)(position + 8));
-        fn_80210FDC(output, translation, output);
+        Vec3* positions = *(Vec3**)(bytes + 0x154);
+        fn_80211484(linked_translation, positions[index].x, positions[index].y,
+                    positions[index].z);
+        fn_80210FDC(output, linked_translation, output);
     }
 
-    fn_802114B8(record_transform, *(float*)(record + 0),
-                *(float*)(record + 4), *(float*)(record + 8));
+    fn_802114B8(record_transform, *(float*)(record + 0), *(float*)(record + 4),
+                *(float*)(record + 8));
     if (apply_record_rotation) {
-        fn_80210FDC(record_transform, (float (*)[4])(record + 0x0C),
-                    record_transform);
+        fn_80210FDC(record_transform, (float (*)[4])(record + 0x0C), record_transform);
     }
     fn_80210FDC(output, record_transform, output);
 
     if (apply_object_transform) {
-        Matrix translation;
-        Matrix rotation;
-        fn_80211484(translation, *(float*)(bytes + 0),
-                    *(float*)(bytes + 4), *(float*)(bytes + 8));
+        fn_80211484(translation, *(float*)(bytes + 0), *(float*)(bytes + 4),
+                    *(float*)(bytes + 8));
         fn_802114E0(rotation, bytes + 0x2C);
         fn_80210FDC(translation, rotation, translation);
         fn_80210FDC(translation, output, output);

--- a/src/game/game_fn_80125664.c
+++ b/src/game/game_fn_80125664.c
@@ -7,7 +7,7 @@ typedef struct Record {
     u32 first;
     u8 pad4[0x114];
     u32 source;
-    u8 pad11C[4];
+    u8 pad11C[8];
     u32 second;
 } Record;
 
@@ -16,11 +16,11 @@ typedef struct Header {
     u32 self_offset;
     u16 count;
     u8 pad16[2];
-    Record* records;
+    s32 records;
     u8 pad1C[4];
-    void* field20;
+    s32 field20;
     u8 pad24[4];
-    void* field28;
+    s32 field28;
 } Header;
 
 typedef struct Buffer {
@@ -32,34 +32,32 @@ extern s32 fn_80125D1C(Header*);
 
 Header* fn_80125664(Header* header, Buffer* buffer)
 {
-    u32 buffer_offset = 0;
+    u8* base;
     s32 i;
+    u32 buffer_offset;
 
-    if (!fn_80125D1C(header))
-        return header;
+    if (fn_80125D1C(header)) {
+        buffer_offset = 0;
+        if (buffer != 0) {
+            buffer_offset = ((buffer->count * 16 + 31) & ~31) + 32;
+        }
 
-    if (buffer != 0) {
-        buffer_offset = ((buffer->count * 16 + 31) & ~31) + 32;
-    }
+        header->self_offset = (u32)header + header->self_offset;
+        header->records = header->records == 0 ? 0 : (s32)header + header->records;
+        header->field20 = header->field20 == 0 ? 0 : (s32)header + header->field20;
+        header->field28 = header->field28 == 0 ? 0 : (s32)header + header->field28;
 
-    header->self_offset = (u32)header + header->self_offset;
-    if (header->records != 0)
-        header->records = (Record*)((u8*)header + (u32)header->records);
-    if (header->field20 != 0)
-        header->field20 = (u8*)header + (u32)header->field20;
-    if (header->field28 != 0)
-        header->field28 = (u8*)header + (u32)header->field28;
-
-    for (i = 0; i < header->count; i++) {
-        Record* record = &header->records[i];
-        u32 source = record->source;
-        record->first = 0;
-        record->second = 0;
-        if (source & 0x40000000)
-            record->source = (u32)((source & 0x3FFFFFFF) +
-                                    (u8*)buffer + buffer_offset);
-        else
-            record->source = (u32)((u8*)header + source);
+        base = (u8*)buffer + buffer_offset;
+        for (i = 0; i < header->count; i++) {
+            Record* record = &((Record*)header->records)[i];
+            u32 source = record->source;
+            record->first = 0;
+            record->second = 0;
+            if (source & 0x40000000)
+                record->source = (source & ~0x40000000) + (u32)base;
+            else
+                record->source = (u32)((u8*)header + source);
+        }
     }
     return header;
 }

--- a/src/game/game_fn_8012C62C.c
+++ b/src/game/game_fn_8012C62C.c
@@ -1,3 +1,4 @@
+typedef signed char s8;
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -6,16 +7,24 @@ extern void* fn_8011FB4C(u8*);
 extern void fn_80125ECC(void *);
 extern void fn_8012F6E8(void*);
 extern void fn_8012CAC4(u8*, int, void*);
-extern int lbl_8064F598;
+extern int lbl_8064CF38;
 
-void* fn_8012C62C(u8* state, int index, void* a, void* b, void* c, int flags)
+typedef struct Slot {
+    u8 pad0[0x48];
+    void* entry;
+} Slot;
+
+void* fn_8012C62C(u8* state, int index, void* a, s8* b, void* c, int flags)
 {
-    u8* entry;
     u8* definition;
+    u8* entry;
 
     if (*(int*)(state + 0x244) == 0x30) {
-        lbl_8064F598++;
-        if (lbl_8064F598 > 2) { }
+        lbl_8064CF38++;
+        if (lbl_8064CF38 > 2) {
+            /* Debugger breakpoint retained from the original limit guard. */
+            asm { nop }
+        }
     }
     fn_8011FB4C(state);
     if (fn_8015C71C() == -1)
@@ -29,11 +38,12 @@ void* fn_8012C62C(u8* state, int index, void* a, void* b, void* c, int flags)
         *(unsigned int*)(entry + 0x38) = *(unsigned int*)c;
         *(unsigned int*)(entry + 0x34) = *(unsigned int*)b;
         fn_8012F6E8(entry + 0xC);
-        if (*(unsigned int*)b != 0)
+        if (b[0] != 0 || b[1] != 0 || b[2] != 0 || b[3] != 0)
             *(u16*)(entry + 0xC) = 1;
-        if (*(void**)(state + 0x160))
-            *(void**)(*(u8**)(state + 0x160) + *(u16*)(definition + 0xE) * 0x4C + 0x48) = entry;
-        *(u16*)(entry + 8) = (*(u16*)(entry + 8) & 0xFFE9) | flags;
+        if (*(Slot**)(state + 0x160))
+            (*(Slot**)(state + 0x160))[*(u16*)(definition + 0xE)].entry = entry;
+        *(u16*)(entry + 8) &= ~0x16;
+        *(u16*)(entry + 8) |= flags;
         fn_8012CAC4(state, index, entry);
     }
     return entry;

--- a/src/game/game_fn_8012F7D4.c
+++ b/src/game/game_fn_8012F7D4.c
@@ -2,13 +2,17 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
+typedef struct Pair {
+    u32 first;
+    u32 second;
+} Pair;
+
 typedef struct Item {
     int id;
     u8 pad4[4];
     u16 flags;
     u8 padA[2];
-    u32 valueC;
-    u32 value10;
+    Pair pair;
     u8 pad14[0x18];
     u32 value2C;
     u32 value30;
@@ -26,8 +30,7 @@ typedef struct Object {
 typedef struct SerializedItem {
     int index;
     u16 flags;
-    u32 valueC;
-    u32 value10;
+    Pair pair;
     u32 value2C;
     u32 value30;
     u32 value34;
@@ -41,35 +44,31 @@ typedef struct SerializedItem {
 extern int fn_8012F700(Object*);
 extern void* memcpy(void*, const void*, unsigned long);
 
-int fn_8012F7D4(void* output, Object* object)
+int fn_8012F7D4(u8* output, Object* object)
 {
     u8 count = fn_8012F700(object);
-    int i;
-    int offset;
     int outputOffset;
+    int i;
 
     memcpy(output, &count, 1);
-    offset = 0;
-    outputOffset = 1;
-    for (i = 0; i < 12; i++, offset += 0x90) {
+    for (i = 0, outputOffset = 1; i < 12; i++) {
         Item* item;
         if (object->items == 0) {
             continue;
         }
-        item = (Item*)((u8*)object->items + offset);
+        item = (Item*)((u8*)object->items + (u32)i * 0x90);
         if (item != 0 && item->id != -1) {
             u16 flags = item->flags;
             if (!(flags & 1) || (flags & 2) || (flags & 4)) {
                 SerializedItem serialized;
                 serialized.index = i;
                 serialized.flags = item->flags;
-                serialized.valueC = item->valueC;
-                serialized.value10 = item->value10;
+                serialized.pair = item->pair;
                 serialized.value2C = item->value2C;
                 serialized.value30 = item->value30;
                 serialized.value34 = item->value34;
                 serialized.value38 = item->value38;
-                memcpy((u8*)output + outputOffset, &serialized, 0x20);
+                memcpy(output + outputOffset, &serialized, 0x20);
                 outputOffset += 0x20;
             }
         }

--- a/src/game/game_fn_8013507C.c
+++ b/src/game/game_fn_8013507C.c
@@ -13,14 +13,15 @@ typedef struct Slot {
 } Slot;
 
 typedef struct Pair { u16 count; u16 pad; void* data; } Pair;
+typedef struct Entry { u32 count; void* array; } Entry;
 typedef struct Object {
     void* records;
     u16 record_count;
     char pad_6[0xA];
-    u32 counts[32];
-    void* arrays[32];
+    Entry entries[32];
     char pad_110[4];
     void* base;
+    char pad_118[4];
     u32 source;
     u32 size;
     Slot* slot;
@@ -31,12 +32,11 @@ typedef struct Manager { char pad_0[0x244]; u32 tag; } Manager;
 extern Slot* fn_80134F7C(Object*);
 extern char* fn_8013523C(Manager*, Object*);
 
-/* NonMatching: honest reconstruction of the file-image fixups and array
- * partitioning. Retail unrolls the second loop four fields at a time. */
 Slot* fn_8013507C(Manager* manager, Object* object)
 {
     Slot* slot = fn_80134F7C(object);
     char* image;
+    char* section;
     int i;
     slot->state = 4;
     object->slot = slot;
@@ -46,17 +46,29 @@ Slot* fn_8013507C(Manager* manager, Object* object)
     slot->field_10 = object->size;
     image = fn_8013523C(manager, object);
     object->base = image + *(u32*)image;
+    section = image + *(u32*)(image + 12);
     object->records = image + *(u32*)(image + 8);
     for (i = 0; i < object->record_count; i++) {
         Pair* p = (Pair*)((char*)object->records + i * 16);
         Pair* q = (Pair*)((char*)p + 8);
-        p->data = p->count ? image + (u32)p->data : 0;
-        q->data = q->count ? image + (u32)q->data : 0;
+        if (p->count == 0) {
+            p->data = 0;
+        } else {
+            p->data = image + (u32)p->data;
+        }
+        if (q->count == 0) {
+            q->data = 0;
+        } else {
+            q->data = image + (u32)q->data;
+        }
     }
-    image += *(u32*)(image + 12);
     for (i = 0; i < 32; i++) {
-        object->arrays[i] = object->counts[i] ? image : 0;
-        image += object->counts[i] * 8;
+        if (object->entries[i].count != 0) {
+            object->entries[i].array = section;
+            section += object->entries[i].count * 8;
+        } else {
+            object->entries[i].array = 0;
+        }
     }
     return slot;
 }

--- a/src/game/game_fn_80138B90.c
+++ b/src/game/game_fn_80138B90.c
@@ -9,8 +9,8 @@ extern u32 lbl_8064CFFC;
 extern u32 lbl_8064D000;
 extern unsigned char* lbl_8064D004;
 extern unsigned char* lbl_8064CFC0;
-extern u32 lbl_8064D00C;
-extern u32 lbl_8064D010;
+extern volatile u32 lbl_8064D00C;
+extern volatile u32 lbl_8064D010;
 
 extern void fn_80213394(void*, Status*);
 extern void fn_8021345C(Status*);
@@ -30,8 +30,8 @@ void* fn_80138B90(void* object, int mode, int alternate)
     } else if (mode == 3) {
         Status status;
         fn_80213394(object, &status);
-        available = 0x3D3100 - lbl_8064D010;
         address = lbl_8064CFC0 + 0x3D3100 - ((status.size + 31) & ~31);
+        available = 0x3D3100 - lbl_8064D010;
         fn_8021345C(&status);
     } else {
         address = lbl_8064CFC0 + lbl_8064D010;

--- a/src/game/game_fn_801391D4.c
+++ b/src/game/game_fn_801391D4.c
@@ -7,9 +7,9 @@ typedef struct Entry {
 
 extern int lbl_8064B9E0;
 extern int lbl_8064B9E4;
-extern unsigned char lbl_8064D068[];
-extern unsigned char lbl_8064D070[];
-extern void* lbl_8064A65C;
+extern char lbl_8064B9E8[7];
+extern char lbl_8064B9F0[2];
+extern void* lbl_8064CFDC;
 extern unsigned char lbl_805AE780[];
 
 extern void* fn_8015D424(void*, int);
@@ -23,18 +23,19 @@ extern void fn_8015D44C(void);
 
 void fn_801391D4(short id, int value)
 {
-    unsigned char temp[64];
-    void* token = fn_8015D424(temp, 2);
+    unsigned char handle[60];
+    unsigned char slot[4];
+    void* token = fn_8015D424(slot, 2);
     Entry* entry;
 
     fn_801399CC(id);
-    fn_802136A4(lbl_8064D068);
-    fn_80213394(lbl_805AE780 + 6, temp + 4);
-    fn_802136A4(lbl_8064D070);
-    entry = fn_80138950(lbl_8064A65C, (u16)value);
-    fn_8015D7D4(0xEA5E40, temp + 4, entry->data, (entry->size + 31) & ~31, token);
+    fn_802136A4(lbl_8064B9E8);
+    fn_80213394(lbl_805AE780 + 6, handle);
+    fn_802136A4(lbl_8064B9F0);
+    entry = fn_80138950(lbl_8064CFDC, (u16)value);
+    fn_8015D7D4(0xEA5E40, handle, entry->data, (entry->size + 31) & ~31, token);
     lbl_8064B9E0 = value;
     lbl_8064B9E4 = id;
-    fn_8021345C(temp + 4);
+    fn_8021345C(handle);
     fn_8015D44C();
 }

--- a/src/game/game_fn_801399CC.c
+++ b/src/game/game_fn_801399CC.c
@@ -1,8 +1,7 @@
 typedef struct Header {
     int file;
-    short value;
     short id;
-    char name[12];
+    char name[14];
 } Header;
 
 typedef struct FileData {
@@ -12,46 +11,49 @@ typedef struct FileData {
 
 extern Header lbl_805AE780;
 extern unsigned char lbl_8024EF08[];
-extern void* lbl_8064A65C;
+extern char lbl_8064B9E8[7];
+extern char lbl_8064B9F0[2];
+extern void* lbl_8064CFDC;
 extern void fn_800F9D4C(char*, const char*, ...);
 extern void fn_80155BB0(const char*, const char*, ...);
 extern void fn_802136A4(void*);
 extern int fn_8021302C(const char*);
-extern int fn_80213320(int, Header*);
-extern int fn_802137F4(Header*, void*, int, int, int);
-extern void fn_8021345C(Header*);
+extern int fn_80213320(int, void*);
+extern int fn_802137F4(void*, void*, int, int, int);
+extern void fn_8021345C(void*);
 
 void fn_801399CC(short id)
 {
-    Header local;
+    unsigned char handle[60];
+    unsigned char* strings = lbl_8024EF08;
     char* name;
+    int code = id;
 
-    if (id == 119) {
-        id = 85;
-    } else if (id == 120) {
-        id = 121;
-    } else if (id == 122) {
-        id = 101;
+    if (code == 119) {
+        code = 85;
+    } else if (code == 120) {
+        code = 121;
+    } else if (code == 122) {
+        code = 101;
     }
 
     if (lbl_805AE780.id != id) {
         lbl_805AE780.id = -1;
         name = lbl_805AE780.name;
-        fn_800F9D4C(name, (char*)lbl_8024EF08 + 0x84);
-        fn_802136A4((void*)0x8064D068);
+        fn_800F9D4C(name, (char*)strings + 0x84, code);
+        fn_802136A4(lbl_8064B9E8);
         lbl_805AE780.file = fn_8021302C(name);
-        fn_802136A4((void*)0x8064D070);
+        fn_802136A4(lbl_8064B9F0);
         if (lbl_805AE780.file != -1) {
-            if (!fn_80213320(lbl_805AE780.file, &local)) {
-                fn_80155BB0((char*)lbl_8024EF08 + 0x94,
-                            (char*)lbl_8024EF08 + 0xAC,
-                            name, lbl_805AE780.file);
+            if (!fn_80213320(lbl_805AE780.file, handle)) {
+                fn_80155BB0((char*)strings + 0x94, (char*)strings + 0xAC, name,
+                            lbl_805AE780.file);
             } else {
-                while (fn_802137F4(&local, lbl_8064A65C, 1024, 0, 2) == -1) {
+                while (fn_802137F4(handle, lbl_8064CFDC, 1024, 0, 2) == -1) {
                 }
-                ((FileData*)lbl_8064A65C)->offset += (int)lbl_8064A65C;
+                ((FileData*)lbl_8064CFDC)->offset += (int)lbl_8064CFDC;
                 lbl_805AE780.id = id;
-                fn_8021345C(&local);
+                fn_8021345C(handle);
             }
         }
     }

--- a/src/game/game_fn_8013E714.c
+++ b/src/game/game_fn_8013E714.c
@@ -22,62 +22,71 @@ extern float fn_8013C418(const Vec3*, const Vec3*, const Vec3*, Vec3*);
 int fn_8013E714(const Capsule* shape, const Vec3* point, Result* out,
                 float extra)
 {
-    Vec3 closest, delta, projected;
-    float outer = shape->radius + extra;
-    float outer2 = outer * outer;
+    Vec3 closest;
+    float outer;
+    float outer2;
     float distance2, center2;
 
-    if (fn_80211D4C(&shape->bound, point) >
-        (shape->bound_radius + extra) * (shape->bound_radius + extra))
-        return 0;
-    fn_8013C35C(&shape->point, &shape->other, &shape->axis,
-                point, &closest, shape->limit);
-    distance2 = fn_80211D4C(&closest, point);
-    if (distance2 >= outer2)
-        return 0;
-    center2 = fn_80211D4C(&shape->point, point);
-    if (center2 <= outer2 + lbl_8065039C) {
-        fn_80211A6C(&shape->point, point, &delta);
-        if (center2 != lbl_80650350)
-            fn_80211A90(&delta, &delta, lbl_80650378 / fn_800ED720(center2));
-        else {
-            delta.x = lbl_80650378;
-            delta.y = lbl_80650350;
-            delta.z = lbl_80650350;
+    if (fn_80211D4C(&shape->bound, point) <=
+        (shape->bound_radius + extra) * (shape->bound_radius + extra)) {
+        outer = extra + shape->radius;
+        outer2 = outer * outer;
+        fn_8013C35C(&shape->point, &shape->other, &shape->axis,
+                    point, &closest, shape->limit);
+        distance2 = fn_80211D4C(&closest, point);
+        if (distance2 < outer2) {
+            center2 = fn_80211D4C(&shape->point, point);
+            if (center2 <= lbl_8065039C + outer2) {
+                Vec3 delta;
+                fn_80211A6C(&shape->point, point, &delta);
+                if (lbl_80650350 != center2)
+                    fn_80211A90(&delta, &delta, lbl_80650378 / fn_800ED720(center2));
+                else {
+                    delta.x = lbl_80650378;
+                    delta.y = lbl_80650350;
+                    delta.z = lbl_80650350;
+                }
+                out->normal.x = point->x + extra * delta.x;
+                out->normal.y = point->y + extra * delta.y;
+                out->normal.z = point->z + extra * delta.z;
+                out->point.x = point->x + outer * delta.x;
+                out->point.y = point->y + outer * delta.y;
+                out->point.z = point->z + outer * delta.z;
+                return 1;
+            }
+            if (lbl_80650350 == distance2) {
+                out->normal.x = point->x - extra * shape->axis.x;
+                out->normal.y = point->y - extra * shape->axis.y;
+                out->normal.z = point->z - extra * shape->axis.z;
+                out->point.x = point->x - outer * shape->axis.x;
+                out->point.y = point->y - outer * shape->axis.y;
+                out->point.z = point->z - outer * shape->axis.z;
+                return 1;
+            }
+            {
+                Vec3 projected;
+                Vec3 delta;
+                float sign;
+
+                sign = fn_8013C418(point, &shape->point, &shape->axis, &projected);
+                distance2 = fn_800ED720(outer2 - fn_80211D4C(point, &projected));
+                if (sign < lbl_80650350) {
+                    out->point.x = projected.x + distance2 * shape->axis.x;
+                    out->point.y = projected.y + distance2 * shape->axis.y;
+                    out->point.z = projected.z + distance2 * shape->axis.z;
+                } else {
+                    out->point.x = projected.x - distance2 * shape->axis.x;
+                    out->point.y = projected.y - distance2 * shape->axis.y;
+                    out->point.z = projected.z - distance2 * shape->axis.z;
+                }
+                fn_80211A6C(point, &out->point, &delta);
+                fn_80211A90(&delta, &delta, lbl_80650378 / outer);
+                out->normal.x = out->point.x + shape->radius * delta.x;
+                out->normal.y = out->point.y + shape->radius * delta.y;
+                out->normal.z = out->point.z + shape->radius * delta.z;
+                return 1;
+            }
         }
-        out->normal.x = point->x + extra * delta.x;
-        out->normal.y = point->y + extra * delta.y;
-        out->normal.z = point->z + extra * delta.z;
-        out->point.x = point->x + outer * delta.x;
-        out->point.y = point->y + outer * delta.y;
-        out->point.z = point->z + outer * delta.z;
-        return 1;
     }
-    if (distance2 == lbl_80650350) {
-        out->normal.x = point->x - extra * shape->axis.x;
-        out->normal.y = point->y - extra * shape->axis.y;
-        out->normal.z = point->z - extra * shape->axis.z;
-        out->point.x = point->x - outer * shape->axis.x;
-        out->point.y = point->y - outer * shape->axis.y;
-        out->point.z = point->z - outer * shape->axis.z;
-        return 1;
-    }
-    fn_8013C418(point, &shape->point, &shape->axis, &projected);
-    distance2 = fn_800ED720(outer2 - fn_80211D4C(point, &projected));
-    out->point = projected;
-    if (fn_8013C418(point, &shape->point, &shape->axis, &delta) < 0.0f) {
-        out->point.x += distance2 * shape->axis.x;
-        out->point.y += distance2 * shape->axis.y;
-        out->point.z += distance2 * shape->axis.z;
-    } else {
-        out->point.x -= distance2 * shape->axis.x;
-        out->point.y -= distance2 * shape->axis.y;
-        out->point.z -= distance2 * shape->axis.z;
-    }
-    fn_80211A6C(point, &out->point, &delta);
-    fn_80211A90(&delta, &delta, lbl_80650378 / outer);
-    out->normal.x = out->point.x + shape->radius * delta.x;
-    out->normal.y = out->point.y + shape->radius * delta.y;
-    out->normal.z = out->point.z + shape->radius * delta.z;
-    return 1;
+    return 0;
 }

--- a/src/game/game_fn_80140010.c
+++ b/src/game/game_fn_80140010.c
@@ -1,7 +1,15 @@
 #pragma use_lmw_stmw on
 
-typedef struct Vec3 { float x, y, z; } Vec3;
-typedef struct Iterator { unsigned char data[12]; } Iterator;
+typedef struct Vec3 {
+    float x, y, z;
+} Vec3;
+
+typedef struct Iterator {
+    unsigned char pad0[4];
+    void* current;
+    unsigned char pad8[4];
+} Iterator;
+
 typedef struct Link {
     unsigned char count;
     unsigned char pad1[3];
@@ -10,44 +18,53 @@ typedef struct Link {
     short secondary;
 } Link;
 typedef struct Owner {
-    unsigned char pad0[0xC]; void* context;
-    unsigned char pad10[0x30]; Link* links;
-    unsigned char pad44[4]; unsigned char* entries;
+    unsigned char pad0[0xC];
+    void* context;
+    unsigned char pad10[0x30];
+    Link* links;
+    unsigned char pad44[4];
+    unsigned char* entries;
 } Owner;
 
 extern float lbl_806503D8;
+extern float lbl_806503DC;
 extern void fn_801E8E54(Iterator*, int, void*);
 extern void fn_801E8E68(Iterator*, int);
 extern int fn_801E8E94(Iterator*);
-extern int fn_8013C7BC(const Vec3*, const Vec3*, float, const Vec3*);
+extern int fn_8013C7BC(const Vec3*, const Vec3*, const Vec3*, float, float);
 extern int fn_8013D998(const Vec3*, const void*, void*, Vec3*);
 extern float fn_80211D4C(const Vec3*, const Vec3*);
 extern void fn_80140AEC(void*, Owner*);
 
 void* fn_80140010(Owner* owner, const Vec3* value, Vec3* out)
 {
-    Iterator outer, inner;
-    unsigned char outer_store[240], inner_store[240];
-    void* result = 0;
+    Iterator inner;
+    Iterator outer;
+    unsigned char inner_store[240];
+    unsigned char outer_store[240];
     unsigned char* entries = owner->entries;
+    void* result = 0;
     fn_801E8E54(&outer, 60, outer_store);
     fn_801E8E54(&inner, 60, inner_store);
     fn_801E8E68(&outer, 0);
     fn_801E8E68(&inner, 0);
-    do {
+    while (outer.current != 0) {
         int a = fn_801E8E94(&outer);
         int b = fn_801E8E94(&inner);
-        if ((b != 0 && (b != 1 || result != 0)) || a == -1) break;
-        {
+        if (!((b != 0 && (b != 1 || result != 0)) || a == -1)) {
+            unsigned char* entry;
             Link* link = &owner->links[a];
-            unsigned char* first = entries + *(unsigned short*)link->indices * 0x38;
-            int side = fn_8013C7BC(value, value + 1, *(float*)(first + 0x20), (Vec3*)(first + 0x14));
+            unsigned char* first =
+                entries + *(unsigned short*)link->indices * 0x38;
+            int side = fn_8013C7BC(value, value + 1, (Vec3*)(first + 0x14),
+                                   lbl_806503DC, *(float*)(first + 0x20));
             if (side == 2) {
                 float best = lbl_806503D8;
                 int i;
-                for (i = 0; i < link->count; i++) {
-                    unsigned char* entry = entries + link->indices[i] * 0x38;
+                int count = link->count;
+                for (i = 0; i < count; i++) {
                     Vec3 candidate;
+                    entry = entries + link->indices[i] * 0x38;
                     if (fn_8013D998(value, entry, owner->context, &candidate)) {
                         float distance = fn_80211D4C(&candidate, value);
                         if (distance < best) {
@@ -58,17 +75,25 @@ void* fn_80140010(Owner* owner, const Vec3* value, Vec3* out)
                         }
                     }
                 }
-                if (result == 0) { fn_801E8E68(&outer, link->secondary); fn_801E8E68(&inner, 1); }
-                fn_801E8E68(&outer, link->primary); fn_801E8E68(&inner, 0);
+                if (result == 0) {
+                    fn_801E8E68(&outer, link->secondary);
+                    fn_801E8E68(&inner, 1);
+                }
+                fn_801E8E68(&outer, link->primary);
+                fn_801E8E68(&inner, 0);
             } else if (side == 3) {
-                fn_801E8E68(&outer, link->primary); fn_801E8E68(&inner, 1);
-                fn_801E8E68(&outer, link->secondary); fn_801E8E68(&inner, 0);
+                fn_801E8E68(&outer, link->primary);
+                fn_801E8E68(&inner, 1);
+                fn_801E8E68(&outer, link->secondary);
+                fn_801E8E68(&inner, 0);
             } else if (side == 0) {
-                fn_801E8E68(&outer, link->secondary); fn_801E8E68(&inner, 0);
+                fn_801E8E68(&outer, link->secondary);
+                fn_801E8E68(&inner, 0);
             } else {
-                fn_801E8E68(&outer, link->primary); fn_801E8E68(&inner, 0);
+                fn_801E8E68(&outer, link->primary);
+                fn_801E8E68(&inner, 0);
             }
         }
-    } while (*(void**)((unsigned char*)&outer + 4) != 0);
+    }
     return result;
 }

--- a/src/game/game_fn_80140408.c
+++ b/src/game/game_fn_80140408.c
@@ -1,32 +1,35 @@
 typedef struct Vec3 { float x, y, z; } Vec3;
 typedef struct Pair { Vec3 a, b; } Pair;
-typedef struct DebugState { int active; int enabled; int unused; } DebugState;
-typedef struct RingState { unsigned char count, head; unsigned char pad[2]; } RingState;
-
-extern DebugState lbl_8064D20C;
-extern RingState lbl_8064D698;
+extern int lbl_8064CB90;
+extern unsigned char lbl_8064D019;
+extern unsigned char lbl_8064D01A;
 extern Pair lbl_805B0EA8[40];
 extern float lbl_806503E0;
-extern float lbl_806503E4;
+extern const float lbl_806503E4;
 
 void fn_80140408(const Vec3* a, const Vec3* b, const Vec3* extent)
 {
+    unsigned char count;
+    Pair* p;
     unsigned char i;
-    if (!lbl_8064D20C.enabled) return;
-    if (a->x >= -extent->x - lbl_806503E0 && a->x <= lbl_806503E0 - extent->x &&
-        a->y >= -extent->y - lbl_806503E0 && a->y <= lbl_806503E0 - extent->y &&
-        a->z >= -extent->z - lbl_806503E0 && a->z <= lbl_806503E0 - extent->z) return;
-    for (i = 0; i < lbl_8064D698.count; i++) {
-        Pair* p = &lbl_805B0EA8[i];
-        if (a->x >= p->a.x - lbl_806503E4 && a->x <= p->a.x + lbl_806503E4 &&
-            a->y >= p->a.y - lbl_806503E4 && a->y <= p->a.y + lbl_806503E4 &&
-            a->z >= p->a.z - lbl_806503E4 && a->z <= p->a.z + lbl_806503E4 &&
-            b->x >= p->b.x - lbl_806503E4 && b->x <= p->b.x + lbl_806503E4 &&
-            b->y >= p->b.y - lbl_806503E4 && b->y <= p->b.y + lbl_806503E4 &&
-            b->z >= p->b.z - lbl_806503E4 && b->z <= p->b.z + lbl_806503E4) return;
+    float margin;
+    if (!lbl_8064CB90) return;
+    margin = lbl_806503E0;
+    if (a->x >= -extent->x - margin && a->x <= margin - extent->x &&
+        a->y >= -extent->y - margin && a->y <= margin - extent->y &&
+        a->z >= -extent->z - margin && a->z <= margin - extent->z) return;
+    count = lbl_8064D01A;
+    for (i = 0; i < count; i++) {
+        p = &lbl_805B0EA8[i];
+        if (a->x >= p->a.x - lbl_806503E4 && a->x <= lbl_806503E4 + p->a.x &&
+            a->y >= p->a.y - lbl_806503E4 && a->y <= lbl_806503E4 + p->a.y &&
+            a->z >= p->a.z - lbl_806503E4 && a->z <= lbl_806503E4 + p->a.z &&
+            b->x >= p->b.x - lbl_806503E4 && b->x <= lbl_806503E4 + p->b.x &&
+            b->y >= p->b.y - lbl_806503E4 && b->y <= lbl_806503E4 + p->b.y &&
+            b->z >= p->b.z - lbl_806503E4 && b->z <= lbl_806503E4 + p->b.z) return;
     }
-    lbl_805B0EA8[lbl_8064D698.head].a = *a;
-    lbl_805B0EA8[lbl_8064D698.head].b = *b;
-    lbl_8064D698.head = (lbl_8064D698.head + 1) % 40;
-    if (++lbl_8064D698.count > 40) lbl_8064D698.count = 40;
+    lbl_805B0EA8[lbl_8064D019].a = *a;
+    lbl_805B0EA8[lbl_8064D019].b = *b;
+    lbl_8064D019 = (lbl_8064D019 + 1) % 40;
+    if (++lbl_8064D01A > 40) lbl_8064D01A = 40;
 }

--- a/src/game/game_fn_80144A2C.c
+++ b/src/game/game_fn_80144A2C.c
@@ -10,11 +10,12 @@ extern MaskThresholds lbl_805B40F0[];
 
 short fn_80144A2C(unsigned int flags, short adjustment, short scale, int index)
 {
+    short value = 0;
     MaskThresholds* entry = &lbl_805B40F0[index];
     unsigned int selected = flags & entry->mask;
-    short value = 0;
     short limit = 0x7FFF;
     int product;
+    int adjust;
 
     if (flags & 0x40000000)
         limit = adjustment + 1;
@@ -22,10 +23,20 @@ short fn_80144A2C(unsigned int flags, short adjustment, short scale, int index)
         value = 0x7FFF;
     if (selected & 0x1F1F)
         value = limit;
-    if (selected & 0x20000000)
-        value = (entry->mask & 1) ? -limit : ((entry->mask & 2) ? limit : value);
-    if (selected & 0x40000000)
-        value = (entry->mask & 4) ? -limit : ((entry->mask & 8) ? limit : value);
+    if (selected & 0x10000000) {
+        if (entry->mask & 1) {
+            value = -limit;
+        } else if (entry->mask & 2) {
+            value = limit;
+        }
+    }
+    if (selected & 0x20000000) {
+        if (entry->mask & 4) {
+            value = -limit;
+        } else if (entry->mask & 8) {
+            value = limit;
+        }
+    }
     if (selected & 0x01000000)
         value = entry->extra[0];
     if (selected & 0x02000000)
@@ -38,20 +49,29 @@ short fn_80144A2C(unsigned int flags, short adjustment, short scale, int index)
         value = entry->low[0];
     if (selected & 0x000C0000)
         value = entry->low[1];
-    if ((flags & 0xFFFFFFFE) && value < 0)
+    if ((flags & 0x80000000) && value < 0) {
         value = -value;
-    else if (value < 0) {
+    } else if (value < 0) {
         value += adjustment;
-        if (value >= 0)
-            return value;
-    } else if (value > 0) {
-        value -= adjustment;
-        if (value <= 0)
-            return 0;
-    } else {
-        return 0;
+        if (value < 0) {
+            product = value * scale;
+            adjust = product % 0x7FFF != 0;
+            if (scale > 0) {
+                adjust = -adjust;
+            }
+            return product / 0x7FFF + adjust;
+        }
     }
-
-    product = value * scale;
-    return product / 0x7FFF;
+    if (value > 0) {
+        value -= adjustment;
+        if (value > 0) {
+            product = value * scale;
+            adjust = product % 0x7FFF != 0;
+            if (scale < 0) {
+                adjust = -adjust;
+            }
+            return product / 0x7FFF + adjust;
+        }
+    }
+    return 0;
 }

--- a/src/game/game_fn_8014CCB0.c
+++ b/src/game/game_fn_8014CCB0.c
@@ -1,89 +1,97 @@
 typedef unsigned char u8;
 typedef unsigned short u16;
 
+typedef signed short s16;
+
 typedef struct Vec3 {
     float x, y, z;
 } Vec3;
 
-#pragma options align=packed
-typedef struct Work {
-    u8 kind;
-    u8 pad01[0x1C];
-    int owner;
-    u8 pad21[0x77];
-} Work;
-#pragma options align=reset
+typedef struct Vec3s {
+    s16 x, y, z;
+} Vec3s;
+
+#pragma pack(1)
+typedef struct FirstDescriptor {
+    u8 pad[0x1D];
+    int source;
+} FirstDescriptor;
+
+typedef struct SecondDescriptor {
+    u8 pad[0x1C];
+    int source;
+} SecondDescriptor;
+
+typedef union WorkDescriptor {
+    u8 bytes[0x98];
+    FirstDescriptor first;
+    SecondDescriptor second;
+} WorkDescriptor;
+#pragma pack()
 
 extern Vec3 lbl_8023A738;
 extern float lbl_8064CF04;
-extern float lbl_806504F8;
-extern float lbl_806504FC;
-extern float lbl_80650500;
+extern const float lbl_806504F8;
+extern const float lbl_806504FC;
+extern const float lbl_80650500;
 extern void* lbl_8064C4E0;
 extern int lbl_802FC5BC[];
 
 extern void fn_8012B690(void*, Vec3*, Vec3*);
-extern unsigned int fn_800FBFB0(void);
-#define fn_800FBFB0() ((int)fn_800FBFB0())
-extern void fn_8017EA58(Work*);
+extern int fn_800FBFB0(void);
+extern void fn_8017EA58(u8*);
 extern int fn_801E79FC(void*, int);
-extern void* fn_80148008(Vec3*, u16*, Work*, void (*)(void));
+extern void* fn_80148008(Vec3*, Vec3s*, u8*, void (*)(void));
 extern void *fn_80156938();
 extern void fn_8017FF1C(void*, int);
-extern void fn_80183DD4(Work*);
+extern void fn_80183DD4(u8*);
 extern void fn_8017EAA8(void);
 extern void fn_80183EE0(void);
 
-/*
- * Honest NonMatching reconstruction of the two effect-spawn paths. The
- * retail function overlays several packed work records in one 0xE0-byte
- * frame; this spelling keeps their behavior and lifetimes explicit.
- */
 void fn_8014CCB0(void* context, int* source, unsigned int packed)
 {
-    u16 range[2];
-    Vec3 second_position;
-    Vec3 first_position;
+    Vec3s range;
     Vec3 position;
     Vec3 basis = lbl_8023A738;
-    Work work;
-    unsigned int kind;
+    Vec3 first_position;
+    Vec3 second_position;
+    WorkDescriptor work;
     void* object;
+    unsigned int kind;
 
     if (!(lbl_8064CF04 >= lbl_806504F8)) {
         fn_8012B690(context, &basis, &position);
-        range[0] = 8 - (fn_800FBFB0() & 0xF);
-        range[1] = 8 - (fn_800FBFB0() & 0xF);
-        fn_8017EA58(&work);
-        work.owner = *source;
+        range.x = 8 - (fn_800FBFB0() & 0xF);
+        range.y = 8 - (fn_800FBFB0() & 0xF);
+        range.z = 8;
+        fn_8017EA58(work.bytes);
+        work.first.source = *source;
         if (fn_801E79FC(lbl_8064C4E0, 0x2ED) != 0)
-            work.owner = lbl_802FC5BC[9];
+            work.first.source = lbl_802FC5BC[9];
 
         if (lbl_8064CF04 >= lbl_806504FC) {
             kind = (packed >> 2) & 0x3F;
-            if ((int)kind <= 0)
-                kind = packed & 0xFF;
+            kind = (int)kind > 0 ? kind : packed & 0xFF;
         } else if (lbl_8064CF04 >= lbl_80650500) {
             kind = (packed >> 1) & 0x7F;
-            if ((int)kind <= 0)
-                kind = packed & 0xFF;
+            kind = (int)kind > 0 ? kind : packed & 0xFF;
         } else {
             kind = packed & 0xFF;
         }
 
-        work.kind = kind;
+        work.bytes[0] = kind;
         first_position = position;
-        object = fn_80148008(&first_position, range, &work, fn_8017EAA8);
+        object = fn_80148008(&first_position, &range, work.bytes, fn_8017EAA8);
         if (object != 0)
             fn_8017FF1C(fn_80156938(object), 4);
-        fn_80183DD4(&work);
+        fn_80183DD4(work.bytes);
 
-        work.owner = *source;
+        work.second.source = *source;
         if (fn_801E79FC(lbl_8064C4E0, 0x2ED) != 0)
-            work.owner = lbl_802FC5BC[9];
-        work.kind = 1;
+            work.second.source = lbl_802FC5BC[9];
+        work.bytes[0] = 1;
         second_position = position;
-        object = fn_80148008(&second_position, range, &work, fn_80183EE0);
+        object = fn_80148008(&second_position, &range, work.bytes, fn_80183EE0);
         if (object != 0)
             fn_8017FF1C(fn_80156938(object), 4);
     }

--- a/src/game/game_fn_80155158.c
+++ b/src/game/game_fn_80155158.c
@@ -3,8 +3,8 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 
 extern int lbl_8064D18C;
-extern u32 lbl_80650008;
-extern u16 lbl_8065000C;
+extern u32 lbl_8065060C;
+extern u16 lbl_80650610;
 extern void fn_80149E28(void*);
 extern int fn_8015C9F0(void);
 extern u32 fn_8015E780(void);
@@ -14,43 +14,52 @@ extern unsigned int fn_800FBFB0(void);
 extern void fn_80179B08(void*, void*);
 extern void fn_80154D24(void*, void*, void*);
 
+typedef struct PackedVector {
+    u32 word;
+    u16 half;
+} PackedVector;
+
 void fn_80155158(void* work)
 {
     char* data = (char*)work + 8;
-    u32 random;
+    int random;
     u16 count;
     u16 selected;
-    char a[8];
-    char b[12];
+    char* entry;
+    char buffer[0x94];
     char c[12];
+    PackedVector a;
+    PackedVector b;
 
     if (*(int*)((char*)work + 0x1324) != lbl_8064D18C ||
-        fn_8015C9F0() != 1 ||
+        fn_8015C9F0() == 1 ||
         (*(u8*)(data + 0xBB) != 0 && *(u32*)(data + 0xB0) != fn_8015E780())) {
         fn_80149E28(work);
         return;
     }
     if (*(u8*)(data + 0xBA) == 0) {
         void* effect = fn_801552AC(data);
-        if (effect == 0) {
+        if (effect != 0) {
+            *(void**)(data + 0x94) = fn_80156938(effect);
+            *(u16*)(data + 0xB4) = (fn_800FBFB0() & 0xFFF) + 1000;
+            *(u8*)(data + 0xBA) = 1;
+        } else {
             fn_80149E28(work);
             return;
         }
-        *(void**)(data + 0x94) = fn_80156938(effect);
-        *(u16*)(data + 0xB4) = (fn_800FBFB0() & 0xFFF) + 1000;
-        *(u8*)(data + 0xBA) = 1;
     }
     count = *(u16*)(data + 0xB4);
     if (count == 0) {
-        *(u32*)a = lbl_80650008;
-        *(u16*)(a + 4) = lbl_8065000C;
+        a.word = lbl_8065060C;
+        a.half = lbl_80650610;
         random = fn_800FBFB0();
         count = *(u16*)(data + 0x64);
-        selected = *(u16*)(data + 0x24 + ((random % count) * 2));
-        *(u32*)b = *(u32*)(*(char**)(data + 0x14) + selected * 24);
-        *(u16*)(b + 4) = *(u16*)(*(char**)(data + 0x14) + selected * 24 + 4);
-        fn_80179B08(b, c);
-        fn_80154D24(c, a, data + 0x1C);
+        selected = ((u16*)(data + 0x24))[random % count];
+        entry = *(char**)(data + 0x14) + selected * 24;
+        b.word = *(u32*)entry;
+        b.half = *(u16*)(entry + 4);
+        fn_80179B08(&b, c);
+        fn_80154D24(c, &a, buffer);
         *(u16*)(data + 0xB4) = (fn_800FBFB0() & 0x7FF) + 60;
     } else {
         *(u16*)(data + 0xB4) = count - 1;

--- a/src/game/game_fn_80156480.c
+++ b/src/game/game_fn_80156480.c
@@ -16,7 +16,7 @@ struct Object {
     char pad24[0x14];
     void* callback_arg;
     char pad3c[8];
-    int flags;
+    unsigned int flags;
 };
 
 #pragma use_lmw_stmw on
@@ -30,7 +30,7 @@ int fn_80156480(Object* object, unsigned int events, unsigned int control)
     int set_mask;
     unsigned int result = 0;
     Child* child;
-    int flags;
+    unsigned int flags;
 
     clear_mask = (control & 0x80) != 0 ? 0x80 : 0x10;
     if ((control & 0x100) != 0) {

--- a/src/game/game_fn_80158D38.c
+++ b/src/game/game_fn_80158D38.c
@@ -30,11 +30,11 @@ extern u32 fn_80178F14(int, int, int, int, int, int);
 int fn_80158D38(Vec3* position, int key, u32 mask, Vec3* output)
 {
     int result;
-    register Record* best;
+    u32 best_distance;
+    Record* best;
     RecordSet* set;
-    register Record* record;
     int i;
-    register u32 best_distance;
+    Record* record;
 
     result = 0;
     best = 0;

--- a/src/game/game_fn_80161798.c
+++ b/src/game/game_fn_80161798.c
@@ -47,9 +47,10 @@ void fn_80161798(Collection* collection)
     Entry* entry;
     Node* node;
     Item* item;
-    Record* record;
     int i;
+    int j;
     int offset;
+    Record* record;
 
     list.nodes = 0;
     list.items = collection->first;
@@ -58,24 +59,30 @@ void fn_80161798(Collection* collection)
     fn_8016152C(collection, &list);
     fn_8016158C(collection, &list);
 
-    while (list.nodes != 0) {
-        node = list.nodes;
-        list.nodes = node->next;
-        entry = (Entry*)node;
-        i = 0;
-        while (i < node->count) {
-            fn_801616EC(&list, entry + 1);
-            entry++;
-            i++;
+    for (;;) {
+        for (;;) {
+            node = list.nodes;
+            if (node == 0) {
+                break;
+            }
+            list.nodes = node->next;
+            entry = (Entry*)node;
+            i = 0;
+            while (i < node->count) {
+                fn_801616EC(&list, entry + 1);
+                entry++;
+                i++;
+            }
         }
-    }
 
-    while (list.items != 0) {
+        if (list.items == 0) {
+            break;
+        }
         item = list.items;
         list.items = item->next;
-        i = 0;
+        j = 0;
         offset = 0;
-        while (i < item->count) {
+        while (j < item->count) {
             record = (Record*)((char*)item->entries + offset);
             if (record->entries[0].kind != 1) {
                 if (record->entries[1].kind == 1)
@@ -84,7 +91,7 @@ void fn_80161798(Collection* collection)
                 fn_801616EC(&list, &record->entries[1]);
             }
             offset += sizeof(Record);
-            i++;
+            j++;
         }
     }
 }

--- a/src/game/game_fn_80167454.c
+++ b/src/game/game_fn_80167454.c
@@ -29,27 +29,24 @@ void fn_80167454(HashTable* table, Value* value)
     HashNode* node;
     int index;
 
-    if (value->type == 2) {
-        return;
-    }
-    if (value->type == 3) {
-        if (*(unsigned int*)((char*)value->data.pointer + 8) > 30) {
-            goto find_key;
-        }
+    if (value->type == 2 ||
+        (value->type == 3 && *(unsigned int*)((char*)value->data.pointer + 8) <= 30)) {
         return;
     }
 
-find_key:
     node = fn_80167128(table, value);
     index = ((char*)node - (char*)table->nodes) / 40;
 
-    do {
+    while (fn_80167264(table, (double)index) != &lbl_8023A868) {
         if (index >= 0x7FFFFFFD - table->size) {
             return;
         }
         index += table->size;
-    } while (fn_80167264(table, (double)index) != &lbl_8023A868);
+    }
 
     value->type = 2;
     value->data.number = (double)index;
 }
+
+#pragma opt_propagation reset
+#pragma use_lmw_stmw off

--- a/src/game/game_fn_801816D4.c
+++ b/src/game/game_fn_801816D4.c
@@ -2,26 +2,22 @@ typedef signed short s16;
 typedef unsigned short u16;
 
 extern s16 lbl_80606360[];
-extern float lbl_8065096C;
+extern const float lbl_8065096C;
 extern double lbl_80650970;
-extern float lbl_8065097C;
-extern float lbl_80650980;
-extern float lbl_80650984;
+extern const float lbl_8065097C;
+extern const float lbl_80650980;
+extern const float lbl_80650984;
 extern float fn_80048C2C(float);
 extern float fn_80048C50(float);
 
 void fn_801816D4(void)
 {
     float angle;
-    s16* table = lbl_80606360;
-    u16 phase = 0;
     int i = 0;
 
-    for (; i < 0x40; i++, phase += 0x400, table++) {
-        angle = lbl_8065096C * (float)phase;
-        angle *= lbl_8065097C;
-        angle /= lbl_80650980;
-        table[0] = (s16)(lbl_80650984 * fn_80048C2C(angle));
-        table[0x40] = (s16)(lbl_80650984 * fn_80048C50(angle));
+    for (; i < 0x40; i++) {
+        angle = lbl_8065096C * (lbl_8065097C * (float)(int)(u16)(i << 10) / lbl_80650980);
+        lbl_80606360[i] = (s16)(lbl_80650984 * fn_80048C2C(angle));
+        lbl_80606360[i + 0x40] = (s16)(lbl_80650984 * fn_80048C50(angle));
     }
 }

--- a/src/game/game_fn_80187968.c
+++ b/src/game/game_fn_80187968.c
@@ -1,38 +1,51 @@
 typedef unsigned char u8;
+typedef signed char s8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
+extern const float lbl_80650A50;
 extern u8 lbl_802FC5BC[];
+
+typedef struct EffectConfig {
+    u8 pad00;
+    u8 field_01;
+    u8 field_02;
+    s8 field_03;
+    u16 field_04;
+    u8 pad06[0xE];
+    u32 field_14;
+    u32 field_18;
+    u32 field_1C;
+    u32 field_20;
+    u8 field_24;
+    u8 field_25;
+    u8 field_26;
+    u8 field_27;
+    u8 pad28[2];
+    u16 field_2A;
+    float field_2C;
+    u32 field_30;
+    u32 field_34;
+} EffectConfig;
 
 void fn_80187968(void* value)
 {
-    u8* p = (u8*)value;
-    u8 value20 = 0x20;
-    u16 six = 6;
-    u8 valueFC = 0xFC;
-    signed char minus4 = -4;
-    u32 zero = 0;
-    u8 five = 5;
-    u8 valueFF = 0xFF;
-    u8* base = lbl_802FC5BC;
-    u16 sixHundred = 0x258;
-    u8 value94 = 0x94;
-    u8 valueF0 = 0xF0;
+    EffectConfig* config = value;
 
-    p[1] = value20;
-    *(u16*)(p + 4) = six;
-    p[2] = valueFC;
-    p[3] = minus4;
-    *(u32*)(p + 0x14) = zero;
-    *(u32*)(p + 0x18) = zero;
-    *(u32*)(p + 0x1C) = zero;
-    p[0x24] = five;
-    p[0x25] = valueFF;
-    *(u32*)(p + 0x20) = zero;
-    *(u32*)(p + 0x30) = *(u32*)(base + 0xC);
-    *(u32*)(p + 0x34) = *(u32*)(base + 0xC);
-    *(u16*)(p + 0x2A) = sixHundred;
-    p[0x26] = value94;
-    *(float*)(p + 0x2C) = 1.0f;
-    p[0x27] = valueF0;
+    config->field_01 = 0x20;
+    config->field_04 = 6;
+    config->field_02 = 0xFC;
+    config->field_03 = -4;
+    config->field_14 = 0;
+    config->field_18 = 0;
+    config->field_1C = 0;
+    config->field_24 = 5;
+    config->field_25 = 0xFF;
+    config->field_20 = 0;
+    config->field_30 = *(u32*)(lbl_802FC5BC + 0xC);
+    config->field_34 = *(u32*)(lbl_802FC5BC + 0xC);
+    config->field_2A = 0x258;
+    config->field_26 = 0x94;
+    config->field_2C = lbl_80650A50;
+    config->field_27 = 0xF0;
 }

--- a/src/game/game_fn_8018AEB0.c
+++ b/src/game/game_fn_8018AEB0.c
@@ -11,11 +11,11 @@ extern void DCFlushRange(void*, unsigned int);
 extern int fn_801ED57C(int);
 extern void fn_8018D0D0(void*, void*, s16);
 extern void fn_801ED468(int);
-extern u8 fn_8017FFB8(void), fn_8017FFB0(void), fn_8017FF98(void);
+extern int fn_8017FFB8(void), fn_8017FFB0(void), fn_8017FF98(void);
 extern void fn_80225F4C(int, void*, u8);
 extern void fn_8018D2E0(float);
 extern void fn_80226AB4(int, int, u16);
-extern void fn_80188578(u16), fn_8018856C(u16), fn_80188560(u16);
+extern void fn_80188578(int), fn_8018856C(int), fn_80188560(int);
 extern void fn_8018855C(void);
 
 void fn_8018AEB0(u8* object)

--- a/src/game/game_fn_801957EC.c
+++ b/src/game/game_fn_801957EC.c
@@ -14,21 +14,25 @@ void fn_801957EC(u8 width, u8 index, Color* data)
     switch (index) {
     case 0:
         data[0].a = 0;
-        data[span * 4 + 3].a = 0;
+        data += span * 4 + 3;
+        data[0].a = 0;
         return;
     case 1:
         data[1].a = 0;
-        data += span * 4 + 5;
+        data++;
+        data += span * 4 + 4;
         data[0].a = 0;
         data[1].a = 0;
         data[2].a = 0;
-        data += span * 4 + 5;
+        data += 2;
+        data += span * 4 + 3;
         data[0].a = 0;
         data[1].a = 0;
         return;
     }
     if (index == width - 1) {
-        data[span * 2 + 2].a = 0;
+        data += span * 2 + 2;
+        data[0].a = 0;
         return;
     }
     if (index == width - 2) {
@@ -45,13 +49,16 @@ void fn_801957EC(u8 width, u8 index, Color* data)
     data += (index - 1) * 2;
     data[0].a = 0;
     data[1].a = 0;
-    data += (span - index + 2) * 4;
+    data++;
+    data += (span - index + 2) * 4 - 1;
     data[0].a = 0;
     data[1].a = 0;
-    data += (index - 2) * 4 + 6;
+    data++;
+    data += (index - 2) * 4 + 5;
     data[0].a = 0;
     data[1].a = 0;
-    data += (span - index + 2) * 4;
+    data++;
+    data += (span - index + 2) * 4 - 1;
     data[0].a = 0;
     data[1].a = 0;
 }

--- a/src/game/game_fn_80199F10.c
+++ b/src/game/game_fn_80199F10.c
@@ -6,19 +6,19 @@ typedef unsigned long u32;
 extern u32 lbl_80651DD0;
 extern u16 lbl_80651DD4;
 extern u32 lbl_80650BD4;
-extern float lbl_80650BC4;
-extern float lbl_80650BD8;
+extern const float lbl_80650BC4;
+extern const float lbl_80650BD8;
 extern void* lbl_8064D224;
-extern u16 lbl_80607122;
+extern u8 lbl_80607120[];
 extern char lbl_80606318[];
 extern char lbl_80606328[];
-extern void fn_801804AC(void*, void*, void*);
+extern void fn_801804AC(void*, void*, void*, void*);
 extern void* memset(void*, int, unsigned long);
 extern void* memcpy(void*, const void*, unsigned long);
 extern void fn_8018F014(void*, u16);
 extern void fn_80180554(void*, void*, void*, void*, int, int);
 extern u32 fn_800FBFB0(void);
-extern void fn_801805E0(void*, int, u8, u32, void*);
+extern void fn_801805E0(void*, int, u8, u8, void*, float);
 extern void fn_8018E230(void*, void*, int, int, u8, int);
 extern void fn_80180518(void*, u8, int);
 extern void fn_8018CB70(void*, u8, u16);
@@ -26,23 +26,28 @@ extern void* fn_8018EF9C(void*);
 extern void fn_8018C540(void*, void**, u8, int, u16);
 extern void fn_801F5A04(void*, s16, char*, char*);
 
+extern const float lbl_80650BCC;
+
 void fn_80199F10(u8* object, void* owner, void* source, u8* config)
 {
+    struct {
+        u32 word;
+        u16 half;
+    } point;
     u8 packet[6];
-    u32 reference;
     u32 seed;
+    void* handle;
     u8 count;
     u8 limit;
-    u8 index;
     u8* entry;
+    u8 index;
     u8 adjusted;
 
+    point.word = lbl_80651DD0;
+    point.half = lbl_80651DD4;
     seed = lbl_80650BD4;
-    *(u32*)packet = lbl_80651DD0;
-    *(u16*)(packet + 4) = lbl_80651DD4;
-    reference = seed;
     count = config[0];
-    fn_801804AC(object, config + 0x20, packet);
+    fn_801804AC(object, config + 0x20, source, &point);
     object[0] = 0x80;
     object[1] = count;
     object[4] = config[3];
@@ -61,18 +66,18 @@ void fn_80199F10(u8* object, void* owner, void* source, u8* config)
     while (index < count) {
         memcpy(packet, config + 0x20, 6);
         fn_8018F014(packet, *(u16*)(config + 0x1e));
-        fn_80180554(entry, packet, source, &reference, 0, 0);
+        fn_80180554(entry, packet, source, &point, 0, 0);
         adjusted = config[1] - (limit & fn_800FBFB0());
-        fn_801805E0(entry + 0x20, 4, adjusted, (u32)index << 2, &seed);
+        fn_801805E0(entry + 0x20, 4, adjusted, index << 2, &seed, lbl_80650BCC);
         fn_8018E230(entry, entry + 0x2b, 1, 0, object[4], 0xcc);
         fn_80180518(object + 0x24, index, 1);
         entry += 0x38;
         index++;
     }
-    fn_8018CB70(*(void**)(object + 0x54), count, lbl_80607122);
-    reference = (u32)fn_8018EF9C(*(void**)(config + 0x2c));
-    fn_8018C540(*(void**)(object + 0x58), (void**)&reference, count, 4,
-                lbl_80607122);
+    fn_8018CB70(*(void**)(object + 0x54), count, *(u16*)(lbl_80607120 + 2));
+    handle = fn_8018EF9C(*(void**)(config + 0x2c));
+    fn_8018C540(*(void**)(object + 0x58), &handle, count, 4,
+                *(u16*)(lbl_80607120 + 2));
     if (*(s16*)(config + 4) >= 0) {
         fn_801F5A04(object + 0x6c, *(s16*)(config + 4), lbl_80606328,
                     lbl_80606318);

--- a/src/game/game_fn_801A3A78.c
+++ b/src/game/game_fn_801A3A78.c
@@ -3,17 +3,17 @@ typedef signed short s16;
 typedef unsigned short u16;
 typedef unsigned long u32;
 
-extern u32 lbl_80650F38;
-extern u16 lbl_80650F3C;
+extern u32 lbl_80651E80;
+extern u16 lbl_80651E84;
 extern u32 lbl_80650D48;
 extern u32 lbl_8064D224;
-extern u8 lbl_802FC5C8[];
+extern u8 lbl_802FC5BC[];
 extern u8 lbl_80607120[];
 extern u8 lbl_80606318[];
 extern u8 lbl_80606328[];
-extern float lbl_80650D44;
-extern float lbl_80650D4C;
-extern float lbl_80650D50;
+extern const float lbl_80650D44;
+extern const float lbl_80650D4C;
+extern const float lbl_80650D50;
 extern float lbl_80650D54;
 
 extern void fn_801804AC(void*, void*, void*, void*);
@@ -22,22 +22,26 @@ extern float fn_80048C2C(float);
 extern float fn_80048C50(float);
 extern void fn_80180554(void*, void*, void*, void*, int, int);
 extern void fn_80180518(void*, int, int);
-extern void fn_801805E0(void*, int, int, u8, int, float, void*);
-extern void fn_8018CEC0(void*, u8);
-extern void fn_8018C540(void*, void*, u8, int);
+extern void fn_801805E0(void*, int, u8, int, float, void*);
+extern void fn_8018CEC0(void*, int);
+extern void fn_8018C540(void*, void*, u8, int, u16);
 extern void fn_801F5A04(void*, s16, void*, void*);
 
 void fn_801A3A78(u8* object, void* coordinate, void* descriptor, u8* owner)
 {
     u8 color[6];
     s16 position[3];
-    u8 count = owner[0];
-    u8* entry = *(u8**)(object + 0x4C);
+    u8 count;
+    u8* entry;
     u8* texture;
+    u32 fallback;
     int i;
 
-    *(u32*)color = lbl_80650F38;
-    *(u16*)(color + 4) = lbl_80650F3C;
+    *(u32*)color = lbl_80651E80;
+    *(u16*)(color + 4) = lbl_80651E84;
+    fallback = lbl_80650D48;
+    count = owner[0];
+    entry = *(u8**)(object + 0x4C);
     fn_801804AC(object, coordinate, descriptor, color);
     object[0] = 0x80;
     object[1] = count;
@@ -51,7 +55,11 @@ void fn_801A3A78(u8* object, void* coordinate, void* descriptor, u8* owner)
     *(float*)(object + 0x3C) = lbl_80650D44;
     *(float*)(object + 0x40) = lbl_80650D4C;
 
-    texture = owner[0x3D] == 0 ? lbl_802FC5C8 + 0xC : descriptor;
+    if (owner[0x3D] == 0) {
+        texture = lbl_802FC5BC + 0xC;
+    } else {
+        texture = (u8*)&fallback;
+    }
     memset(object + 0x24, 0, 0x10);
     for (i = 0; (u8)i < count; i++) {
         float fraction = lbl_80650D50 * (float)(u8)i / (float)count;
@@ -63,11 +71,11 @@ void fn_801A3A78(u8* object, void* coordinate, void* descriptor, u8* owner)
         fn_80180554(entry, position, descriptor, color, 0, 0);
         if (owner[0x3D] == 0)
             fn_80180518(object + 0x24, i, 1);
-        fn_801805E0(entry + 0x20, 4, 0, owner[1], 0, lbl_80650D54, texture);
+        fn_801805E0(entry + 0x20, 4, owner[1], 0, lbl_80650D54, texture);
         entry += 0x38;
     }
     fn_8018CEC0(*(void**)(object + 0x54), count);
-    fn_8018C540(*(void**)(object + 0x58), lbl_802FC5C8 + 0xC, count, 4);
+    fn_8018C540(*(void**)(object + 0x58), lbl_802FC5BC + 0xC, count, 4, *(u16*)(lbl_80607120 + 2));
     if (*(s16*)(owner + 4) >= 0)
         fn_801F5A04(object + 0x6C, *(s16*)(owner + 4), lbl_80606328, lbl_80606318);
 }

--- a/src/game/game_fn_801A5910.c
+++ b/src/game/game_fn_801A5910.c
@@ -17,10 +17,14 @@ void fn_801A5910(int enabled)
 {
     int i;
 
-    for (i = 0; i < 6; i++) {
+    for (i = 0; i < 9; i++) {
         if (lbl_806079C0[i].callback == fn_801A5F40 ||
             lbl_806079C0[i].callback == fn_801A5F54) {
-            lbl_806079C0[i].value = enabled ? -72 : 72;
+            if (enabled) {
+                lbl_806079C0[i].value = -72;
+            } else {
+                lbl_806079C0[i].value = 72;
+            }
         }
     }
 }

--- a/src/game/game_fn_801A59CC.c
+++ b/src/game/game_fn_801A59CC.c
@@ -23,20 +23,15 @@ extern void fn_801A5FB0(void);
 void fn_801A59CC(void* value)
 {
     void* object;
+    int i;
 
     fn_801A6CB4();
-    lbl_806079C0[0].value = value;
-    lbl_806079C0[1].value = value;
-    lbl_806079C0[2].value = value;
-    lbl_806079C0[3].value = value;
-    lbl_806079C0[4].value = value;
-    lbl_806079C0[5].value = value;
-    lbl_806079C0[6].value = value;
-    lbl_806079C0[7].value = value;
-    lbl_806079C0[8].value = value;
-    lbl_802512A4[0].value = value;
-    lbl_802512A4[1].value = value;
-    lbl_802512A4[2].value = value;
+    for (i = 0; i < 3; i++) {
+        lbl_802512A4[i].value = value;
+    }
+    for (i = 0; i < 9; i++) {
+        lbl_806079C0[i].value = value;
+    }
 
     object = fn_80144628(3, lbl_802512A4, 0);
     lbl_8064D26C = object;

--- a/src/game/game_fn_801A7D44.c
+++ b/src/game/game_fn_801A7D44.c
@@ -12,6 +12,9 @@ typedef struct Object801A7D44 {
     u16 count;
     u8 padB2[2];
     Entry801A7D44* entries;
+    u8 padB8[0x808A];
+    signed char enabled_8142;
+    signed char ready_8143;
 } Object801A7D44;
 
 extern Object801A7D44* fn_8015C28C(int);
@@ -19,14 +22,12 @@ extern Object801A7D44* fn_8015C28C(int);
 void fn_801A7D44(void)
 {
     Object801A7D44* object = fn_8015C28C(2);
-    if (object != 0 && *(signed char*)((u8*)object + 0x8142) != 0 &&
-        *(signed char*)((u8*)object + 0x8143) != 0) {
+    if (object != 0 && object->enabled_8142 != 0 && object->ready_8143 != 0) {
         u16 count = object->count;
         Entry801A7D44* entry = object->entries;
-        while (count > 0) {
+        int i;
+        for (i = 0; i < count; i++, entry++) {
             entry->value = 0;
-            entry++;
-            count--;
         }
     }
 }

--- a/src/game/game_fn_801AAB38.c
+++ b/src/game/game_fn_801AAB38.c
@@ -40,16 +40,13 @@ void fn_801AAB38(void)
     fourth = source_fourth;
     fn_801F68D4(&third);
 
-    first_ptr = &lbl_80608020.first;
-    first_ptr->x = first.x;
+    (first_ptr = &lbl_80608020.first)->x = first.x;
     lbl_80608020.first.y = first.y;
     lbl_80608020.first.z = first.z;
-    third_ptr = &lbl_80608020.third;
-    third_ptr->x = third.x;
+    (third_ptr = &lbl_80608020.third)->x = third.x;
     lbl_80608020.third.y = third.y;
     lbl_80608020.third.z = third.z;
-    fourth_ptr = &lbl_80608020.fourth;
-    fourth_ptr->x = fourth.x;
+    (fourth_ptr = &lbl_80608020.fourth)->x = fourth.x;
     lbl_80608020.fourth.y = fourth.y;
     lbl_80608020.fourth.z = fourth.z;
     fn_801C9510(&lbl_80608020, first_ptr, &lbl_80608020.second,

--- a/src/game/game_fn_801AD08C.c
+++ b/src/game/game_fn_801AD08C.c
@@ -1,7 +1,20 @@
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned long u32;
-typedef struct EffectNode { struct EffectNode* next; int state, object_id, timer, handle, resource; u16 kind, value; u8 x, y, flushed, queued; } EffectNode;
+typedef struct EffectNode {
+    struct EffectNode* next;
+    int state;
+    int object_id;
+    int timer;
+    int handle;
+    int resource;
+    u16 kind;
+    u16 value;
+    u8 x;
+    u8 y;
+    u8 flushed;
+    u8 queued;
+} EffectNode;
 extern EffectNode* lbl_8064D304;
 extern int lbl_8064D300, lbl_8064C2D0;
 extern u8 lbl_8060B060[];
@@ -10,44 +23,115 @@ extern int fn_800E4594(void), fn_801AD7C0(int, int);
 extern void fn_801B151C(int, void*, int, int, void*), fn_801B17B0(int), fn_801B17A8(int);
 extern void fn_801ACF80(EffectNode*), fn_801ACFB0(void), fn_801AD46C(u8*, u8*), fn_801ACCA0(int, int);
 extern void fn_801E8328(int, int), fn_801A98F4(u16, u8), DCFlushRange(void*, unsigned long), fn_801ACFE8(u32);
-static int clamp127(int v) { return v > 127 ? 127 : v > 0 ? v : 0; }
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define clamp127(v) MIN(127, MAX(v, 0))
 void fn_801AD08C(void)
 {
-    EffectNode* node = lbl_8064D304;
-    int active, a, b; u8 x, y;
-    if (node == 0) return;
+    EffectNode* node;
+    int active;
+    int result;
+    u8 a;
+    u8 b;
+    int qa;
+    int qb;
+    u8 x;
+    u8 y;
+
+    if ((node = lbl_8064D304) == 0) {
+        return;
+    }
     switch (node->state) {
     case 1:
-        if (fn_801B191C() == 3) break;
+        if (fn_801B191C() == 3) {
+            break;
+        }
         active = 1;
         if (node->object_id != lbl_8064C2D0 && lbl_8064D300 != 3 && lbl_8064D300 != 2) {
-            a = fn_800E4594();
-            if (node->kind != 0 || node->queued == 1) { active = 0; node->state = 7; DCFlushRange(node, 0x20); }
+            result = fn_800E4594();
+            if (node->kind != 0 || node->queued == 1) {
+                active = 0;
+                node->state = 7;
+                DCFlushRange(node, 0x20);
+            }
             node->resource = fn_801AD7C0(node->resource, 1);
-            fn_801B151C(a, lbl_8060B060, 0x3f, node->resource, fn_801ACFE8);
-            if (node->kind != 0 || node->queued == 1) { lbl_8064D300 = 4; fn_801B17B0(4); }
-            else { lbl_8064D300 = 3; fn_801B17B0(1); }
-            fn_801B17A8(node->handle); lbl_8064C2D0 = node->object_id;
+            fn_801B151C(result, lbl_8060B060, 0x3f, node->resource, fn_801ACFE8);
+            if (node->kind != 0 || node->queued == 1) {
+                lbl_8064D300 = 4;
+                fn_801B17B0(4);
+            } else {
+                lbl_8064D300 = 3;
+                fn_801B17B0(1);
+            }
+            fn_801B17A8(node->handle);
+            lbl_8064C2D0 = node->object_id;
         }
-        if (active) fn_801ACF80(node);
+        if (active) {
+            fn_801ACF80(node);
+        }
         break;
     case 7:
-        if (node->flushed == 1) { fn_801B17B0(1); lbl_8064D300 = 3; if (node->kind != 0) fn_801E8328(0x18, node->kind); fn_801ACF80(node); }
+        if (node->flushed == 1) {
+            fn_801B17B0(1);
+            lbl_8064D300 = 3;
+            if (node->kind != 0) {
+                fn_801E8328(0x18, node->kind);
+            }
+            fn_801ACF80(node);
+        }
         break;
     case 5:
-        fn_801AD46C(&x, &y); a = clamp127(x + (node->x - x) / node->timer); b = clamp127(y + (node->y - y) / node->timer);
-        fn_801ACCA0(a, b); node->timer--; if (node->timer == 0 || (a == node->x && b == node->y)) { fn_801ACF80(node); node->timer = 0; }
+        fn_801AD46C(&x, &y);
+        qa = (node->x - x) / node->timer;
+        qb = (node->y - y) / node->timer;
+        a = clamp127(x + qa);
+        b = clamp127(y + qb);
+        fn_801ACCA0(a, b);
+        node->timer--;
+        if (node->timer == 0 || (a == node->x && b == node->y)) {
+            fn_801ACF80(node);
+            node->timer = 0;
+        }
         break;
     case 2:
-        if (fn_801B191C() != 3) { if (lbl_8064D300 == 3 || lbl_8064D300 == 2) { fn_801B17B0(0); fn_801ACFB0(); } else fn_801B17B0(0); fn_801ACF80(node); }
+        if (fn_801B191C() != 3) {
+            if (lbl_8064D300 == 3 || lbl_8064D300 == 2) {
+                fn_801B17B0(0);
+                fn_801ACFB0();
+            } else {
+                fn_801B17B0(0);
+            }
+            fn_801ACF80(node);
+        }
         break;
     case 3:
-        if (fn_801B191C() != 3) { if (lbl_8064D300 == 3) { fn_801B17B0(2); lbl_8064D300 = 2; } fn_801ACF80(node); }
+        if (fn_801B191C() != 3) {
+            if (lbl_8064D300 == 3) {
+                fn_801B17B0(2);
+                lbl_8064D300 = 2;
+            }
+            fn_801ACF80(node);
+        }
         break;
     case 4:
-        if (fn_801B191C() != 3) { if (lbl_8064D300 == 2) { fn_801B17B0(1); lbl_8064D300 = 3; } fn_801ACF80(node); }
+        if (fn_801B191C() != 3) {
+            if (lbl_8064D300 == 2) {
+                fn_801B17B0(1);
+                lbl_8064D300 = 3;
+            }
+            fn_801ACF80(node);
+        }
         break;
-    case 8: if (node->timer != 0) node->timer--; else fn_801ACF80(node); break;
-    case 9: fn_801A98F4(node->value, node->x); fn_801ACF80(node); break;
+    case 8:
+        if (node->timer != 0) {
+            node->timer--;
+        } else {
+            fn_801ACF80(node);
+        }
+        break;
+    case 9:
+        fn_801A98F4(node->value, node->x);
+        fn_801ACF80(node);
+        break;
     }
 }

--- a/src/game/game_fn_801BE874.c
+++ b/src/game/game_fn_801BE874.c
@@ -1,27 +1,30 @@
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef unsigned long long u64;
+
+#pragma pack(1)
 typedef struct StreamState {
     u8 pad_000[0x114]; u64 flags_114; u8 pad_11C[5];
-    u8 channel_121; u8 subchannel_122; u8 pad_123[0x11];
-    u8 mode_134[4];
+    u8 channel_121; u8 subchannel_122; u8 pad_123[0xE];
+    u8 mode_131; u8 pad_132[2]; u32 duration_134;
 } StreamState;
+#pragma pack()
 typedef struct StreamCommand { u32 value; u32 flags; } StreamCommand;
 extern void fn_801CC408(u32*);
 extern void fn_801CC418(u32*, StreamState*);
 extern void fn_801CA7C0(int, u8, u8, int);
-extern u32 fn_801CAFAC(int, u8, u8);
+extern unsigned short fn_801CAFAC(int, u8, u8);
 extern void fn_801B5B9C(StreamState*);
 
 void fn_801BE874(StreamState* state, StreamCommand* command)
 {
-    u32 duration;
     u32 mode;
-    state->mode_134[0] = (command->value >> 16) & 0xFF;
+    u32 duration;
+    state->mode_131 = (command->value >> 16) & 0xFF;
     duration = command->flags >> 16;
     if ((command->flags >> 8) & 1) fn_801CC408(&duration);
     else fn_801CC418(&duration, state);
-    *(u32*)state->mode_134 = duration;
+    state->duration_134 = duration;
     mode = (command->value >> 8) & 0xFF;
     switch (mode) {
     case 0:
@@ -30,6 +33,7 @@ void fn_801BE874(StreamState* state, StreamCommand* command)
         break;
     case 1:
         if (state->channel_121 != 0xFF) fn_801CA7C0(0x41, state->channel_121, state->subchannel_122, 0x7F);
+    enable:
         if ((state->flags_114 & 0x400ULL) == 0) fn_801B5B9C(state);
         state->flags_114 |= 0x400ULL;
         break;
@@ -37,7 +41,5 @@ void fn_801BE874(StreamState* state, StreamCommand* command)
         if (state->channel_121 != 0xFF && fn_801CAFAC(0x41, state->channel_121, state->subchannel_122) > 0x1F80)
             goto enable;
         break;
-    enable:
-        state->flags_114 |= 0x400ULL;
     }
 }

--- a/src/game/game_fn_801C7684.c
+++ b/src/game/game_fn_801C7684.c
@@ -23,27 +23,32 @@ extern Group lbl_80628CB0[];
 
 void fn_801C7684(Entry* entry, u8 group)
 {
+    Group* groups = lbl_80628CB0;
+    Entry* next;
+
     if (entry->active != 0) {
         if (entry->previous != 0) {
             entry->previous->next = entry->next;
         } else {
-            lbl_80628CB0[entry->group].head = entry->next;
+            groups[entry->group].head = entry->next;
         }
 
         if (entry->next != 0) {
             entry->next->previous = entry->previous;
         }
 
-        entry->next = lbl_80628CB0[group].head;
-        if (entry->next != 0) {
+        next = groups[group].head;
+        entry->next = next;
+        if (next != 0) {
             entry->next->previous = entry;
         }
         entry->previous = 0;
-        lbl_80628CB0[group].head = entry;
+        groups[group].head = entry;
 
         if (entry->active == 2) {
-            entry->next_secondary = lbl_80628CB0[entry->group].secondary_head;
-            lbl_80628CB0[entry->group].secondary_head = entry;
+            u8* secondary = (u8*)&groups->secondary_head;
+            entry->next_secondary = *(Entry**)(secondary + entry->group * sizeof(Group));
+            *(Entry**)(secondary + entry->group * sizeof(Group)) = entry;
         }
     }
     entry->group = group;

--- a/src/game/game_fn_801CA59C.c
+++ b/src/game/game_fn_801CA59C.c
@@ -2,12 +2,12 @@ extern float lbl_80651018;
 
 void fn_801CA59C(float* output, float* input)
 {
-    float inverse;
     float negative_inverse;
+    float inverse;
     float c0;
     float c1;
-    float c2;
     float determinant;
+    float c2;
 
     c0 = input[4] * input[8] - input[7] * input[5];
     c1 = -(input[3] * input[8] - input[6] * input[5]);


### PR DESCRIPTION
## Progress

This raises matched code from 34.37% to 35.28%: 790,636 to 811,776 of 2,300,692 code bytes, 4,925 to 4,978 of 8,216 functions, and 5,160 to 5,213 of 6,259 objects. It adds 53 matched functions, 53 matched objects, and 21,140 matched code bytes.

## Current behavior

These 53 game functions are marked `NonMatching`. Their remaining differences include control-flow structure, declaration order and scope, operand order, integer types, function declarations, structure layouts, compiler options, and ownership of compiler-generated tables and constants.

## New behavior

All 53 functions are marked `Matching`. Each function matches the target instructions and relocation names and addresses.

## How

### Control flow and expressions

- Reconstructed switch case groupings, loop forms, branch order, and shared return paths where the previous source emitted different control flow.
- Reordered operands and split or combined expressions where the target instruction sequence required a different source expression.
- Replaced byte-offset accesses with typed record and entry layouts that preserve the observed field offsets.

### Declarations and types

- Corrected integer widths, signedness, return types, parameter types, and local structure layouts where they changed loads, stores, comparisons, or call sequences.
- Adjusted declaration order and scope to reproduce the target register allocation and value lifetimes.
- Enabled `-use_lmw_stmw on` for five functions whose target prologues and epilogues use the corresponding save and restore instructions.

### Compiler-generated data

- Added guarded externalization steps for ten objects whose compiler-generated jump tables, conversion constants, or read-only table correspond to existing target symbols.
- The externalization steps reject missing or non-file-backed generated symbols. Non-relocation-backed values are also checked byte-for-byte against the target; strict objdiff verifies the resulting relocation-backed tables.

## Testing

| Function | Code bytes | Relocations | Instructions | Strict relocations |
| --- | ---: | ---: | ---: | ---: |
| `fn_80049818` | 372 | 5 | 100% | equal |
| `fn_8004998C` | 1256 | 55 | 100% | equal |
| `fn_80068290` | 340 | 14 | 100% | equal |
| `fn_8006845C` | 328 | 4 | 100% | equal |
| `fn_8006EA4C` | 276 | 13 | 100% | equal |
| `fn_800723A8` | 244 | 13 | 100% | equal |
| `fn_80079AA4` | 428 | 17 | 100% | equal |
| `fn_80087A24` | 388 | 22 | 100% | equal |
| `fn_8008D6E4` | 784 | 41 | 100% | equal |
| `fn_8008D9F4` | 436 | 18 | 100% | equal |
| `fn_8008E110` | 388 | 11 | 100% | equal |
| `fn_8008E294` | 324 | 15 | 100% | equal |
| `fn_8008F224` | 912 | 40 | 100% | equal |
| `fn_800A3104` | 124 | 1 | 100% | equal |
| `fn_800AAD14` | 276 | 9 | 100% | equal |
| `fn_800AF230` | 164 | 10 | 100% | equal |
| `fn_800B002C` | 428 | 44 | 100% | equal |
| `fn_800B84DC` | 388 | 23 | 100% | equal |
| `fn_800C1D60` | 500 | 27 | 100% | equal |
| `fn_800DFD54` | 348 | 8 | 100% | equal |
| `fn_8011F140` | 224 | 5 | 100% | equal |
| `fn_8011F41C` | 344 | 10 | 100% | equal |
| `fn_80125664` | 292 | 1 | 100% | equal |
| `fn_8012C62C` | 328 | 7 | 100% | equal |
| `fn_8012F7D4` | 248 | 3 | 100% | equal |
| `fn_8013507C` | 448 | 2 | 100% | equal |
| `fn_80138B90` | 324 | 19 | 100% | equal |
| `fn_801391D4` | 196 | 17 | 100% | equal |
| `fn_801399CC` | 336 | 34 | 100% | equal |
| `fn_8013E714` | 840 | 19 | 100% | equal |
| `fn_80140010` | 584 | 24 | 100% | equal |
| `fn_80140408` | 580 | 27 | 100% | equal |
| `fn_80144A2C` | 532 | 10 | 100% | equal |
| `fn_8014CCB0` | 488 | 35 | 100% | equal |
| `fn_80155158` | 340 | 14 | 100% | equal |
| `fn_80156480` | 352 | 7 | 100% | equal |
| `fn_80158D38` | 324 | 3 | 100% | equal |
| `fn_80161798` | 312 | 7 | 100% | equal |
| `fn_80167454` | 260 | 6 | 100% | equal |
| `fn_801816D4` | 308 | 12 | 100% | equal |
| `fn_80187968` | 128 | 5 | 100% | equal |
| `fn_8018AEB0` | 424 | 30 | 100% | equal |
| `fn_801957EC` | 372 | 0 | 100% | equal |
| `fn_80199F10` | 460 | 28 | 100% | equal |
| `fn_801A3A78` | 672 | 35 | 100% | equal |
| `fn_801A5910` | 188 | 18 | 100% | equal |
| `fn_801A59CC` | 212 | 37 | 100% | equal |
| `fn_801A7D44` | 168 | 1 | 100% | equal |
| `fn_801AAB38` | 216 | 20 | 100% | equal |
| `fn_801AD08C` | 888 | 48 | 100% | equal |
| `fn_801BE874` | 356 | 6 | 100% | equal |
| `fn_801C7684` | 184 | 9 | 100% | equal |
| `fn_801CA59C` | 508 | 1 | 100% | equal |

Strict objdiff comparison with `function_reloc_diffs=name_address` reports 100% instructions and equal relocation names and addresses for all 53 functions, covering 21,140 code bytes and 890 relocation sites.

- `python3 configure.py`
- `.tools/bin/ninja -j1`
- `build/GEDE01/main.dol` SHA-1: `ea24b6af954876ce072562ff39cdb4c81d32be1f`
- `python3 tools/legal_audit.py`
- `git diff --check`

The final build reports 811,776 of 2,300,692 matched code bytes, 4,978 of 8,216 matched functions, and 5,213 of 6,259 complete objects.

## Other

### Approaches that did not work

- `fn_80049818`: switches without the additional case labels reached 95.4409%; placing states 12-20 under `default` reached 93.2903%; placing both states 0-9 and 12-20 under `default` reached 93.2903%.
- `fn_8004998C`: compiler versions GC/1.0 through GC/3.0a5 at optimization levels O1 through O4 all reached 99.0223%; alternative `default` case groupings reached 98.3471% to 99.3949%.
- `fn_80068290`: wrapping the body under the 0x80 check reached 85.18%; three return tails with `state` declared first reached 99.65%.
- `fn_8006845C`: the guards alone reached 84.88%; placing the list guard before the owner call reached 93.84%.
- `fn_8006EA4C`: the flag change alone reached 84.49%; alternative nesting and declaration orders reached 98.91% to 99.57%.
- `fn_800723A8`: a single exit alone reached 97.62%; alternative declaration order, an unsigned position copy, and computing the offset through `result` reached 98.03% to 98.28%.
- `fn_80079AA4`: alternative operand orders for the two field comparisons reached 99.02% to 99.63%.
- `fn_80087A24`: casting the storage to a slot structure beginning at offset 0x68 reached 89.02%.
- `fn_8008D6E4`: symbol changes alone reached 87.24%; a single exit reached 93.91%; masking the call result reached 94.21% to 95.85%; layout and declaration-order variants reached 99.49% to 99.82%.
- `fn_8008D9F4`: alternative local declarations reached 97.25% to 98.17%; computing the owner ID earlier reached 90.05%; `-schedule off` reached 78.35%.
- `fn_8008E110`: the mask and operand swap alone reached 98.7629%; replacing the selection with a plain `if` produced the same result.
- `fn_8008E294`: selecting the target through a pointer reached 96.54%; a ternary reached 99.32%; an alternate declaration order reached 99.88%; multiple-return forms reached 84% to 92% and duplicated a call.
- `fn_8008F224`: declaring kind and mode before position reached 88.50%; inline boolean expressions reached 96.47%; other declaration orders reached 99.47% to 99.71%.
- `fn_800A3104`: `int` and `u8` forms of `old_value` reached 96.6129%; `s16` and `u32` forms did not compile in this unit.
- `fn_800AAD14`: conditional-expression and `if`/`else` forms of the mask both reached 88.2464%.
- `fn_800AF230`: block scope alone reached 99.2683%, leaving only relocation symbol-name differences.
- `fn_800B002C`: declaring the same local after `object` or last reached 99.81%.
- `fn_800B84DC`: short return types for the lookup functions reached 84.59%; integer locals with casts reached 93.51%; adding a separate index alone reached 99.48%.
- `fn_800C1D60`: declaration-order and alias variants reached 93.016% to 99.08%; assigning the alias inside a call argument matched but was not used.
- `fn_800DFD54`: `(u8)-5`, plain `-5`, `char` storage, and an integer delta local all reached 99.99% because the unsigned store folded to `0xfb`.
- `fn_8011F140`: plain locals inside the assembly block did not compile; register locals reached 98.13%; alternative product and comparison orders reached 98.66%.
- `fn_8011F41C`: the flag change alone reached 92.69%; a resolved temporary reached 97.34%; placing the matrices in another order reached 99.91%.
- `fn_80125664`: single-exit, mask, base, offset, and ternary variants reached 71.85% to 96.16%; signed-record and pointer-add variants reached 99.86%.
- `fn_8012C62C`: default flags reached 86.46%; a `while` guard reached 96.22%.
- `fn_8012F7D4`: alternate loop initialization, declaration order, and offset-local positions reached 96.5% to 99.8%; a pointer copy or comma operand reached 99.81%.
- `fn_8013507C`: retaining the ternaries reached 58.5%; alternative branch orders reached 65.8% to 79.5%; alternate placement of the section calculation reached 95.8% to 97.3%; a named byte offset reached 94.7%.
- `fn_80138B90`: the operand swap alone reached 98.2099%; parenthesized address arithmetic reached 90.4198% to 90.5432%; adding `volatile` to `lbl_8064D010` reached 97.2840%.
- `fn_801391D4`: symbol changes alone reached 80.45%; sized strings and a structure containing the handle each reached 89.86%.
- `fn_801399CC`: layout and handle changes alone reached 88.21%; retaining the original ID comparison without the formatter argument reached 87.64%; a fixed three-argument formatter declaration reached 98.81%.
- `fn_8013E714`: a single exit alone reached 92.33%; adding block scope and operand-order changes reached 92.63%.
- `fn_80140010`: declaration, loop, signature, cached-count, and guard variants reached 96.1507% to 99.4521%.
- `fn_80140408`: the symbol swap alone reached 83.0%; placing both constants in locals reached 97.07%; the margin local alone reached 98.62%; a count local reached 99.52%.
- `fn_80144A2C`: corrected masks alone reached 53.5%; assignment and shared-tail variants reached 59.6% to 68.1%; early-return and declaration-order variants reached 92.4% to 99.1%.
- `fn_8014CCB0`: `u16 range[3]` did not compile against the previous prototype; structure, byte-buffer, comparison, declaration-order, and early-return variants reached 93.1885% to 98.3607%.
- `fn_80155158`: symbol changes alone reached 86.92%; polarity and buffer changes reached 87.94%; copying through a record structure reached 86.75%.
- `fn_80156480`: routing updates through a local, using single expressions, inline set and clear helpers, and an inline accessor reached 99.375% to 99.545456%.
- `fn_80158D38`: five other declaration orders reached 98.52% to 99.26%; broader declaration-order searches found no exact alternative.
- `fn_80161798`: separate top-tested loops reached 90.5% to 96.5%; testing the node before the copy reached 98.5%; other declaration orders reached 99.1% to 99.5%.
- `fn_80167454`: `while`, combined-condition, and alternate comparison forms reached 98.1539%; `switch` forms reached 93.2769%; compiler versions GC/1.2.5 through GC/1.3.2 at optimization levels O1 through O4 did not exceed 98.1539%.
- `fn_801816D4`: constant, signed-phase, and table-assignment variants reached 93.44% to 95.32%; an indexed table with a phase local reached 99.35%.
- `fn_80187968`: the signed store alone reached 99.84%.
- `fn_8018AEB0`: changing only the return types reached 98.8208%; alternate loop-index types reached 87.2642% to 96.9811%; a `u32` index did not compile.
- `fn_80199F10`: reading the configuration tail through a pointer local reached 98.87%; removing the cast without correcting the parameter type reached 99.96%.
- `fn_801A3A78`: the symbol swap alone reached 80.61%; a `u8` loop index reached 97.05%; other compiler builds reached 61% to 63%.
- `fn_801A5910`: hoisted and loop-local value variables reached 20.1915% and 73.1702%; an `if`/`else` with a six-entry bound and a `while` form reached 99.9787%; a countdown loop reached 89.1915%.
- `fn_801A59CC`: moving the unrolled `lbl_802512A4` stores first reached 94.0377%; retaining the original loop order or using separate indices reached 99.6226%.
- `fn_801A7D44`: indexed entry loops reached 1.8% to 62.5%; an `int` count reached 91.1%; rereading the bound on each iteration reached 31.5%.
- `fn_801AD08C`: assigning the node before the test reached 92.77%; processing the second axis first reached 92.83%; nested `MIN` and `MAX` with the bound last reached 95.77%.
- `fn_801BE874`: layout, field-split, return-type, and label-placement variants reached 94.93% to 99.96%.
- `fn_801C7684`: table-local, alternate layout, element-pointer, secondary-pointer, linked-node, index-local, and inline byte-offset variants reached 0% to 91.6304%.
